### PR TITLE
Address review feedback on NaN handling

### DIFF
--- a/baseline_models/ha.py
+++ b/baseline_models/ha.py
@@ -18,7 +18,6 @@ def historical_average_predict(df, period=12 * 24 * 7, test_ratio=0.2):
     """
     
     df = df.copy()
-    df = df.fillna(0)
 
     n_sample, n_sensor = df.shape
     n_test = int(round(n_sample * test_ratio))
@@ -29,7 +28,7 @@ def historical_average_predict(df, period=12 * 24 * 7, test_ratio=0.2):
     for i in range(n_train, min(n_sample, n_train + period)):
         inds = [j for j in range(i % period, n_train, period)]
         historical = df.iloc[inds, :]
-        y_predict.iloc[i - n_train, :] = historical[historical != 0.0].mean()
+        y_predict.iloc[i - n_train, :] = historical.mean(skipna=True)
     # Copy each period.
     for i in range(n_train + period, n_sample, period):
         size = min(period, n_sample - i)

--- a/baseline_models/util.py
+++ b/baseline_models/util.py
@@ -18,7 +18,6 @@ def time_splits(series_or_df, train_frac=0.7, val_frac=0.1):
 
 def wide2long(path):
     df=pd.read_csv(path+"/series.csv")
-    df = df.fillna(0)
     #For each column c after and including the third column, make a dataframe composed of the first two columns and c
     ts_col, node_col = df.columns[:2]
     out=[]
@@ -55,7 +54,7 @@ def load_h5(path):
 def _resolve_mask(labels, mask=None):
     """Compute a validity mask for label arrays.
 
-    Missing targets are assumed to be encoded as ``0``. Any provided mask is
+    Missing targets are assumed to be encoded as ``NaN``. Any provided mask is
     broadcast to match ``labels`` and returned directly.
 
     Parameters
@@ -77,7 +76,8 @@ def _resolve_mask(labels, mask=None):
             mask = np.broadcast_to(mask, labels.shape)
         return mask
 
-    return np.asarray(labels) != 0
+    labels_arr = np.asarray(labels, dtype=float)
+    return ~np.isnan(labels_arr)
 
 
 def _masked_mean(values, mask):
@@ -116,9 +116,8 @@ def mae(y_true, y_pred, mask=None):
         Predicted values.
     mask : numpy.ndarray, optional
         Boolean array selecting entries to include in the computation. When not
-        provided, entries equal to ``0`` in ``y_true`` are treated as missing
-        data and ignored. Any NaNs in the inputs should already be replaced
-        with ``0`` when loading the data.
+        provided, entries with ``NaN`` in ``y_true`` are treated as missing data
+        and ignored.
 
     Returns
     -------
@@ -141,9 +140,8 @@ def rmse(y_true, y_pred, mask=None):
         Predicted values.
     mask : numpy.ndarray, optional
         Boolean array selecting entries to include in the computation. When not
-        provided, entries equal to ``0`` in ``y_true`` are treated as missing
-        data and ignored. Any NaNs in the inputs should already be replaced
-        with ``0`` when loading the data.
+        provided, entries with ``NaN`` in ``y_true`` are treated as missing data
+        and ignored.
 
     Returns
     -------
@@ -167,9 +165,8 @@ def mape(y_true, y_pred, mask=None, eps=1e-6):
         Predicted values.
     mask : numpy.ndarray, optional
         Boolean array selecting entries to include in the computation. When not
-        provided, entries equal to ``0`` in ``y_true`` are treated as missing
-        data and ignored. Any NaNs in the inputs should already be replaced
-        with ``0`` when loading the data.
+        provided, entries with ``NaN`` in ``y_true`` are treated as missing data
+        and ignored.
     eps : float, optional
         Small constant added to the denominator to avoid division by zero.
 

--- a/datasets_prep/beijing_air.py
+++ b/datasets_prep/beijing_air.py
@@ -161,7 +161,11 @@ def _convert_to_ir(in_path, out_path, node_ids, features=KEPT_FEATURES):
     df = df[df[ts_col] > pd.Timestamp("2014-01-01")] 
 
     feat_cols = [c for c in features if c in df.columns[2:]]
-    df = df[[ts_col, node_col, *feat_cols]]
+    df = df[[ts_col, node_col, *feat_cols]].copy()
+
+    # Treat zeros as missing values as soon as we have the feature columns
+    if feat_cols:
+        df.loc[:, feat_cols] = df.loc[:, feat_cols].where(df.loc[:, feat_cols] != 0)
 
     # Sort by timestamp, then node_id
     df = df.sort_values(by=[ts_col, node_col]).reset_index(drop=True)

--- a/datasets_prep/pems_speed.py
+++ b/datasets_prep/pems_speed.py
@@ -75,6 +75,10 @@ def _individual_prepare_data(out_dir, dataset):
             .rename_axis(["ts", "node_id"])
             .reset_index(name="value")
     )
+    value_cols = long.columns[2:]
+    if len(value_cols):
+        long = long.copy()
+        long.loc[:, value_cols] = long.loc[:, value_cols].where(long.loc[:, value_cols] != 0)
     return long
 
 def _individual_prepare_adj(out_dir, dataset):
@@ -103,6 +107,7 @@ def prepare(download=True, cleanup=True, out_path=OUT_DEFAULT_PATH, dataset_sele
         (out_path/ds).mkdir(parents=True, exist_ok=True)
         df=_individual_prepare_data(out_path, ds)
         df.to_csv(out_path/ds/"series.csv", index=False)
+
         df=_individual_prepare_adj(out_path, ds)
         df.to_csv(out_path/ds/"edges.csv", index=False)
 

--- a/datasets_prep/pems_volume.py
+++ b/datasets_prep/pems_volume.py
@@ -75,6 +75,7 @@ def _individual_prepare(out_dir, dataset):
     # Creates on indexed dataframe for each of the three dimensions
     idx = pd.date_range(date, periods=arr.shape[0], freq="5min")
     dfs = [pd.DataFrame(x.squeeze(-1), index=idx) for x in np.split(arr, 3, axis=-1)]
+    dfs = [df.where(df != 0) for df in dfs]
     
     #Transform those dataframes into our long format.
     names = ['flow','occupancy','speed']
@@ -83,7 +84,7 @@ def _individual_prepare(out_dir, dataset):
     
     #Combine them into one dataframe:
     df= pd.concat([d.set_index('node', append=True) for d in longs], axis=1).rename_axis(['ts','node']).sort_index()
-    
+
     #Output it to our directory
     dest = out_dir / name
     dest.mkdir(parents=True, exist_ok=True) 


### PR DESCRIPTION
## Summary
- remove redundant zero-to-NaN masking from the historical average baseline so it relies on NaN inputs
- keep NaNs intact when converting wide datasets without re-encoding values in baseline utilities
- simplify the PeMS speed preparation loop while retaining the NaN conversion in the data helper

## Testing
- python -m compileall baseline_models datasets_prep

------
https://chatgpt.com/codex/tasks/task_e_68dccbbe51a48320aa91c47c6745af99