### PR TITLE
Refactor exporters to follow DatasetLoader pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ ir.apply(ZScoreNormalize(train_end="2015-01-01"))
 
 # 4. Export for a specific model
 exporter = STAEformerExporter()
-result = exporter.export_from_workspace(
+result = exporter.export(
+    workspace,
     ir,
     window_config=WindowConfig(input_length=12, horizon=12)
 )
@@ -182,8 +183,10 @@ loader = BeijingAirLoader(subdivision="all")      # 437 nodes
 
 ### Export Configuration
 
+Exporters follow the same pattern as dataset loaders: `exporter.export(workspace, ir, ...)`.
+
 ```python
-from gnn_benchmark.exporters import WindowConfig, SplitConfig
+from gnn_benchmark.exporters import STAEformerExporter, WindowConfig, SplitConfig
 
 # Configure sliding windows
 window_config = WindowConfig(
@@ -201,8 +204,12 @@ split_config = SplitConfig(
     # test_ratio = 0.2 (implicit)
 )
 
-# Export
-result = exporter.export(ir, output_dir, window_config, split_config)
+# Export using workspace (recommended)
+exporter = STAEformerExporter()
+result = exporter.export(workspace, ir, window_config, split_config)
+
+# Or use the convenience method if IR is already linked to workspace
+result = exporter.export_from_workspace(ir, window_config, split_config)
 ```
 
 ## Baseline Models
@@ -288,6 +295,12 @@ workspace.list_exports("beijing_air")
 ir = workspace.load("beijing_air")
 ir = workspace.load("beijing_air", from_clean=True)
 
+# Prepare dataset (download + convert)
+ir = workspace.prepare(loader)
+
+# Export to model format
+result = workspace.export(exporter, ir, window_config, split_config)
+
 # Save/clear
 workspace.save_working(ir)
 workspace.clear_working("beijing_air")
@@ -369,23 +382,45 @@ class MyTransform(Transform):
 #### Custom Exporter
 
 ```python
-from gnn_benchmark.exporters import ModelExporter, ExportResult
+from gnn_benchmark.exporters import ModelExporter, ExportResult, WindowConfig, SplitConfig
+from pathlib import Path
 
 class MyExporter(ModelExporter):
     @property
     def name(self) -> str:
         return "my_model"
 
-    def export(self, ir, output_dir, window_config, split_config):
+    def export_to_directory(
+        self,
+        ir,
+        output_dir: Path,
+        window_config: WindowConfig,
+        split_config: SplitConfig,
+    ) -> ExportResult:
         # Use helper methods
         data = ir.to_tensor()
-        x, y = self._create_sliding_windows(data, ...)
-        train_x, val_x, test_x = self._split_by_time(x, ...)
+        x, y = self._create_sliding_windows(
+            data,
+            window_config.input_length,
+            window_config.horizon,
+        )
+        train_x, val_x, test_x = self._split_by_time(
+            x,
+            split_config.train_ratio,
+            split_config.val_ratio,
+        )
 
         # Save in your format
+        output_dir.mkdir(parents=True, exist_ok=True)
         ...
 
-        return ExportResult(files={"data": path}, ...)
+        return ExportResult(
+            files={"data": output_dir / "data.npz"},
+            window_config=window_config,
+            split_config=split_config,
+        )
+
+# Usage: exporter.export(workspace, ir, window_config, split_config)
 ```
 
 ## Data Format Specifications

--- a/core/workspace.py
+++ b/core/workspace.py
@@ -8,6 +8,12 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from gnn_benchmark.datasets.base import DatasetLoader
+    from gnn_benchmark.exporters.base import (
+        ExportResult,
+        ModelExporter,
+        SplitConfig,
+        WindowConfig,
+    )
 
 from gnn_benchmark.core.intermediate import IntermediateRepresentation
 
@@ -277,6 +283,50 @@ class DataWorkspace:
 
         if export_path.exists():
             shutil.rmtree(export_path)
+
+    # --- Export ---
+
+    def export(
+        self,
+        exporter: "ModelExporter",
+        ir: IntermediateRepresentation,
+        window_config: "WindowConfig | None" = None,
+        split_config: "SplitConfig | None" = None,
+    ) -> "ExportResult":
+        """
+        Export an IR using the given exporter.
+
+        This method follows the same pattern as prepare() for dataset loaders.
+        The exporter writes files to: workspace/exports/{dataset_name}/{exporter_name}/
+
+        Args:
+            exporter: ModelExporter instance to use for export.
+            ir: IntermediateRepresentation to export.
+            window_config: Window configuration. Uses exporter defaults if None.
+            split_config: Split configuration. Uses exporter defaults if None.
+
+        Returns:
+            ExportResult with paths to created files and metadata.
+
+        Raises:
+            ValueError: If IR has no dataset name.
+        """
+        # Import here to avoid circular imports
+        from gnn_benchmark.exporters.base import SplitConfig, WindowConfig
+
+        dataset_name = ir.dataset_name or ir.metadata.name
+        if not dataset_name:
+            raise ValueError("IR must have a dataset name for export")
+
+        # Determine output directory
+        output_dir = self.exports_dir / dataset_name / exporter.name
+
+        # Use defaults if not provided
+        window_cfg = window_config or WindowConfig()
+        split_cfg = split_config or SplitConfig()
+
+        # Delegate to exporter's implementation
+        return exporter.export_to_directory(ir, output_dir, window_cfg, split_cfg)
 
     def __repr__(self) -> str:
         datasets = self.list_datasets()

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -5,8 +5,12 @@ This module provides exporters that convert the IntermediateRepresentation
 to formats expected by various GNN models. Each exporter handles windowing,
 train/val/test splitting, and format-specific file generation.
 
+Exporters follow the same pattern as DatasetLoaders: the primary entry point
+is exporter.export(workspace, ir, ...) which delegates to workspace.export().
+
 Classes:
     ModelExporter: Abstract base class for implementing custom exporters.
+        Subclasses implement export_to_directory() to write files.
 
     Configuration classes:
         WindowConfig: Sliding window parameters (input_length, horizon, y_start).
@@ -22,13 +26,23 @@ Classes:
         D2STGCNExporter: Format for D2STGCN model.
 
 Example:
+    >>> from gnn_benchmark import DataWorkspace
     >>> from gnn_benchmark.exporters import STAEformerExporter, WindowConfig
+    >>>
+    >>> workspace = DataWorkspace("./my_workspace")
+    >>> ir = workspace.load("my_dataset")
+    >>>
+    >>> # Export using workspace (recommended)
     >>> exporter = STAEformerExporter()
-    >>> result = exporter.export_from_workspace(
+    >>> result = exporter.export(
+    ...     workspace,
     ...     ir,
     ...     window_config=WindowConfig(input_length=12, horizon=12)
     ... )
     >>> print(result.files)
+    >>>
+    >>> # Or use the convenience method if IR is already linked to workspace
+    >>> result = exporter.export_from_workspace(ir)
 """
 
 from gnn_benchmark.exporters.base import ModelExporter, WindowConfig, SplitConfig, ExportResult

--- a/exporters/astgcn.py
+++ b/exporters/astgcn.py
@@ -29,7 +29,7 @@ class ASTGCNExporter(ModelExporter):
     def name(self) -> str:
         return "astgcn"
 
-    def export(
+    def export_to_directory(
         self,
         ir: IntermediateRepresentation,
         output_dir: Path,

--- a/exporters/base.py
+++ b/exporters/base.py
@@ -9,26 +9,44 @@ import numpy as np
 
 if TYPE_CHECKING:
     from gnn_benchmark.core.intermediate import IntermediateRepresentation
+    from gnn_benchmark.core.workspace import DataWorkspace
 
 
 @dataclass
 class WindowConfig:
-    """Configuration for sliding window creation."""
+    """
+    Configuration for sliding window creation.
 
-    input_length: int = 12  # L: number of past timesteps
-    horizon: int = 12  # H: number of future timesteps to predict
-    y_start: int = 1  # Gap between input end and target start
-    input_columns: list[str] | None = None  # None = all feature columns
-    target_columns: list[str] | None = None  # None = same as input_columns
+    Attributes:
+        input_length: Number of past timesteps (L) to use as input.
+        horizon: Number of future timesteps (H) to predict.
+        y_start: Gap between input end and target start. Default is 1,
+            meaning target starts immediately after input.
+        input_columns: Feature columns to use for input. None means all columns.
+        target_columns: Feature columns to predict. None means same as input_columns.
+    """
+
+    input_length: int = 12
+    horizon: int = 12
+    y_start: int = 1
+    input_columns: list[str] | None = None
+    target_columns: list[str] | None = None
 
 
 @dataclass
 class SplitConfig:
-    """Configuration for train/val/test split."""
+    """
+    Configuration for temporal train/val/test split.
+
+    The test ratio is computed as 1 - train_ratio - val_ratio.
+
+    Attributes:
+        train_ratio: Fraction of data for training (e.g., 0.7 for 70%).
+        val_ratio: Fraction of data for validation (e.g., 0.1 for 10%).
+    """
 
     train_ratio: float = 0.7
     val_ratio: float = 0.1
-    # test_ratio is implicit: 1 - train_ratio - val_ratio
 
     def __post_init__(self):
         if self.train_ratio + self.val_ratio >= 1.0:
@@ -38,39 +56,66 @@ class SplitConfig:
 
     @property
     def test_ratio(self) -> float:
+        """Compute the test ratio as the remainder."""
         return 1.0 - self.train_ratio - self.val_ratio
 
 
 @dataclass
 class ExportResult:
-    """Result of an export operation."""
+    """
+    Result of an export operation.
 
-    files: dict[str, Path]  # name -> path mapping
+    Attributes:
+        files: Mapping of file names to their paths.
+        window_config: The window configuration used.
+        split_config: The split configuration used.
+        stats: Optional statistics (e.g., normalization parameters).
+        metadata: Additional metadata about the export.
+    """
+
+    files: dict[str, Path]
     window_config: WindowConfig
     split_config: SplitConfig
-    stats: dict[str, Any] | None = None  # Optional: normalization stats, etc.
+    stats: dict[str, Any] | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class ModelExporter(ABC):
     """
-    Base class for model-specific exporters.
+    Abstract base class for model-specific exporters.
 
-    Handles windowing, splitting, and format conversion from IR to
-    model-specific formats.
+    Exporters convert an IntermediateRepresentation to model-specific formats,
+    handling windowing, splitting, and file format conversion.
+
+    This class follows a similar pattern to DatasetLoader: the primary entry
+    point is the `export()` method which takes a workspace and delegates to
+    `workspace.export()`.
 
     Subclasses must implement:
-        - name: Property returning the exporter/model name
-        - export: Method to export IR to model-specific format
+        - name: Property returning the exporter/model name (used for directories).
+        - export_to_directory: Method to write files to a specific directory.
+
+    Example:
+        >>> exporter = STAEformerExporter()
+        >>> result = exporter.export(
+        ...     workspace,
+        ...     ir,
+        ...     window_config=WindowConfig(input_length=12, horizon=12),
+        ... )
+        >>> print(result.files)
     """
 
     @property
     @abstractmethod
     def name(self) -> str:
-        """Exporter/model name (used for directory naming)."""
+        """
+        Exporter/model name.
+
+        Used for naming the export subdirectory under workspace/exports/{dataset}/.
+        """
 
     @abstractmethod
-    def export(
+    def export_to_directory(
         self,
         ir: "IntermediateRepresentation",
         output_dir: Path,
@@ -78,17 +123,51 @@ class ModelExporter(ABC):
         split_config: SplitConfig,
     ) -> ExportResult:
         """
-        Export IR to model-specific format.
+        Export IR to model-specific format in the given directory.
+
+        This is the method subclasses must implement. It performs the actual
+        conversion and file writing.
 
         Args:
-            ir: The intermediate representation
-            output_dir: Where to write output files
-            window_config: Sliding window parameters
-            split_config: Train/val/test split ratios
+            ir: The intermediate representation to export.
+            output_dir: Directory where output files should be written.
+            window_config: Sliding window parameters.
+            split_config: Train/val/test split ratios.
 
         Returns:
-            ExportResult with paths to created files
+            ExportResult with paths to created files and metadata.
         """
+
+    def export(
+        self,
+        workspace: "DataWorkspace",
+        ir: "IntermediateRepresentation",
+        window_config: WindowConfig | None = None,
+        split_config: SplitConfig | None = None,
+    ) -> ExportResult:
+        """
+        Export IR using a workspace.
+
+        This is the primary entry point for exporting, following the same pattern
+        as DatasetLoader.prepare(). It delegates to workspace.export().
+
+        Output goes to: workspace/exports/{dataset_name}/{exporter_name}/
+
+        Args:
+            workspace: DataWorkspace to use for export.
+            ir: IntermediateRepresentation to export.
+            window_config: Window configuration. Uses defaults if None.
+            split_config: Split configuration. Uses defaults if None.
+
+        Returns:
+            ExportResult with paths to created files.
+        """
+        return workspace.export(
+            self,
+            ir,
+            window_config=window_config,
+            split_config=split_config,
+        )
 
     def export_from_workspace(
         self,
@@ -97,30 +176,32 @@ class ModelExporter(ABC):
         split_config: SplitConfig | None = None,
     ) -> ExportResult:
         """
-        Export using workspace's export directory structure.
+        Export using workspace linked to the IR.
+
+        This is a convenience method when the IR is already linked to a workspace.
+        For new code, prefer using `export(workspace, ir, ...)` directly.
 
         Output goes to: workspace/exports/{dataset_name}/{exporter_name}/
 
         Args:
-            ir: IntermediateRepresentation linked to a workspace
-            window_config: Window configuration (uses defaults if None)
-            split_config: Split configuration (uses defaults if None)
+            ir: IntermediateRepresentation linked to a workspace.
+            window_config: Window configuration. Uses defaults if None.
+            split_config: Split configuration. Uses defaults if None.
 
         Returns:
-            ExportResult with paths to created files
+            ExportResult with paths to created files.
 
         Raises:
-            ValueError: If IR is not linked to a workspace
+            ValueError: If IR is not linked to a workspace.
         """
         if ir.workspace is None or ir.dataset_name is None:
             raise ValueError("IR must be linked to workspace for this method")
 
-        output_dir = ir.workspace.exports_dir / ir.dataset_name / self.name
         return self.export(
+            ir.workspace,
             ir,
-            output_dir,
-            window_config or WindowConfig(),
-            split_config or SplitConfig(),
+            window_config=window_config,
+            split_config=split_config,
         )
 
     # --- Helper methods for subclasses ---

--- a/exporters/d2stgcn.py
+++ b/exporters/d2stgcn.py
@@ -28,7 +28,7 @@ class D2STGCNExporter(ModelExporter):
     def name(self) -> str:
         return "d2stgcn"
 
-    def export(
+    def export_to_directory(
         self,
         ir: IntermediateRepresentation,
         output_dir: Path,

--- a/exporters/graph_wavenet.py
+++ b/exporters/graph_wavenet.py
@@ -35,7 +35,7 @@ class GraphWaveNetExporter(ModelExporter):
     def name(self) -> str:
         return "graph_wavenet"
 
-    def export(
+    def export_to_directory(
         self,
         ir: IntermediateRepresentation,
         output_dir: Path,

--- a/exporters/gts.py
+++ b/exporters/gts.py
@@ -30,7 +30,7 @@ class GTSExporter(ModelExporter):
     def name(self) -> str:
         return "gts"
 
-    def export(
+    def export_to_directory(
         self,
         ir: IntermediateRepresentation,
         output_dir: Path,

--- a/exporters/mtgnn.py
+++ b/exporters/mtgnn.py
@@ -32,7 +32,7 @@ class MTGNNExporter(ModelExporter):
     def name(self) -> str:
         return "mtgnn"
 
-    def export(
+    def export_to_directory(
         self,
         ir: IntermediateRepresentation,
         output_dir: Path,

--- a/exporters/staeformer.py
+++ b/exporters/staeformer.py
@@ -30,7 +30,7 @@ class STAEformerExporter(ModelExporter):
     def name(self) -> str:
         return "staeformer"
 
-    def export(
+    def export_to_directory(
         self,
         ir: IntermediateRepresentation,
         output_dir: Path,


### PR DESCRIPTION
- Add export() method to DataWorkspace for consistent API
- Rename ModelExporter.export() to export_to_directory()
- Add ModelExporter.export(workspace, ir, ...) as primary entry point
- Keep export_from_workspace() for backward compatibility
- Update all concrete exporters (STAEformer, GraphWaveNet, ASTGCN, etc.)
- Update README and module docstrings with new usage pattern

The exporter API now mirrors the dataset loader pattern:
  loader.prepare(workspace) → workspace.prepare(loader)
  exporter.export(workspace, ir) → workspace.export(exporter, ir)

https://claude.ai/code/session_013qSzjDUPx18Ce1dUH3v5kt