### PR TITLE
Simplify exporter API by removing workspace parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ ir.apply(ZScoreNormalize(train_end="2015-01-01"))
 # 4. Export for a specific model
 exporter = STAEformerExporter()
 result = exporter.export(
-    workspace,
     ir,
     window_config=WindowConfig(input_length=12, horizon=12)
 )
@@ -186,8 +185,6 @@ loader = BeijingAirLoader(subdivision="all")      # 437 nodes
 
 ### Export Configuration
 
-Exporters follow the same pattern as dataset loaders: `exporter.export(workspace, ir, ...)`.
-
 ```python
 from gnn_benchmark.exporters import STAEformerExporter, WindowConfig, SplitConfig
 
@@ -207,12 +204,9 @@ split_config = SplitConfig(
     # test_ratio = 0.2 (implicit)
 )
 
-# Export using workspace (recommended)
+# Export the IR (must be linked to workspace)
 exporter = STAEformerExporter()
-result = exporter.export(workspace, ir, window_config, split_config)
-
-# Or use the convenience method if IR is already linked to workspace
-result = exporter.export_from_workspace(ir, window_config, split_config)
+result = exporter.export(ir, window_config, split_config)
 ```
 
 ## Baseline Models
@@ -423,7 +417,7 @@ class MyExporter(ModelExporter):
             split_config=split_config,
         )
 
-# Usage: exporter.export(workspace, ir, window_config, split_config)
+# Usage: exporter.export(ir, window_config, split_config)
 ```
 
 ## Data Format Specifications

--- a/__init__.py
+++ b/__init__.py
@@ -27,7 +27,7 @@ Example usage:
 
     # Export for specific model
     exporter = STAEformerExporter()
-    result = exporter.export_from_workspace(
+    result = exporter.export(
         ir,
         window_config=WindowConfig(input_length=12, horizon=12)
     )

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -5,9 +5,6 @@ This module provides exporters that convert the IntermediateRepresentation
 to formats expected by various GNN models. Each exporter handles windowing,
 train/val/test splitting, and format-specific file generation.
 
-Exporters follow the same pattern as DatasetLoaders: the primary entry point
-is exporter.export(workspace, ir, ...) which delegates to workspace.export().
-
 Classes:
     ModelExporter: Abstract base class for implementing custom exporters.
         Subclasses implement export_to_directory() to write files.
@@ -32,17 +29,12 @@ Example:
     >>> workspace = DataWorkspace("./my_workspace")
     >>> ir = workspace.load("my_dataset")
     >>>
-    >>> # Export using workspace (recommended)
     >>> exporter = STAEformerExporter()
     >>> result = exporter.export(
-    ...     workspace,
     ...     ir,
     ...     window_config=WindowConfig(input_length=12, horizon=12)
     ... )
     >>> print(result.files)
-    >>>
-    >>> # Or use the convenience method if IR is already linked to workspace
-    >>> result = exporter.export_from_workspace(ir)
 """
 
 from gnn_benchmark.exporters.base import ModelExporter, WindowConfig, SplitConfig, ExportResult

--- a/exporters/base.py
+++ b/exporters/base.py
@@ -9,7 +9,6 @@ import numpy as np
 
 if TYPE_CHECKING:
     from gnn_benchmark.core.intermediate import IntermediateRepresentation
-    from gnn_benchmark.core.workspace import DataWorkspace
 
 
 @dataclass
@@ -87,9 +86,8 @@ class ModelExporter(ABC):
     Exporters convert an IntermediateRepresentation to model-specific formats,
     handling windowing, splitting, and file format conversion.
 
-    This class follows a similar pattern to DatasetLoader: the primary entry
-    point is the `export()` method which takes a workspace and delegates to
-    `workspace.export()`.
+    The primary entry point is the `export()` method which takes an IR linked
+    to a workspace and delegates to `workspace.export()`.
 
     Subclasses must implement:
         - name: Property returning the exporter/model name (used for directories).
@@ -97,8 +95,8 @@ class ModelExporter(ABC):
 
     Example:
         >>> exporter = STAEformerExporter()
+        >>> ir = workspace.load("my_dataset")
         >>> result = exporter.export(
-        ...     workspace,
         ...     ir,
         ...     window_config=WindowConfig(input_length=12, horizon=12),
         ... )
@@ -140,46 +138,12 @@ class ModelExporter(ABC):
 
     def export(
         self,
-        workspace: "DataWorkspace",
         ir: "IntermediateRepresentation",
         window_config: WindowConfig | None = None,
         split_config: SplitConfig | None = None,
     ) -> ExportResult:
         """
-        Export IR using a workspace.
-
-        This is the primary entry point for exporting, following the same pattern
-        as DatasetLoader.prepare(). It delegates to workspace.export().
-
-        Output goes to: workspace/exports/{dataset_name}/{exporter_name}/
-
-        Args:
-            workspace: DataWorkspace to use for export.
-            ir: IntermediateRepresentation to export.
-            window_config: Window configuration. Uses defaults if None.
-            split_config: Split configuration. Uses defaults if None.
-
-        Returns:
-            ExportResult with paths to created files.
-        """
-        return workspace.export(
-            self,
-            ir,
-            window_config=window_config,
-            split_config=split_config,
-        )
-
-    def export_from_workspace(
-        self,
-        ir: "IntermediateRepresentation",
-        window_config: WindowConfig | None = None,
-        split_config: SplitConfig | None = None,
-    ) -> ExportResult:
-        """
-        Export using workspace linked to the IR.
-
-        This is a convenience method when the IR is already linked to a workspace.
-        For new code, prefer using `export(workspace, ir, ...)` directly.
+        Export IR to model-specific format.
 
         Output goes to: workspace/exports/{dataset_name}/{exporter_name}/
 
@@ -195,10 +159,10 @@ class ModelExporter(ABC):
             ValueError: If IR is not linked to a workspace.
         """
         if ir.workspace is None or ir.dataset_name is None:
-            raise ValueError("IR must be linked to workspace for this method")
+            raise ValueError("IR must be linked to a workspace")
 
-        return self.export(
-            ir.workspace,
+        return ir.workspace.export(
+            self,
             ir,
             window_config=window_config,
             split_config=split_config,


### PR DESCRIPTION
## Summary
Simplifies the exporter API by removing the `workspace` parameter from the `export()` method. Exporters now require the IR to be pre-linked to a workspace, eliminating the need for two separate methods and reducing API complexity.

## Changes
- **Removed `workspace` parameter** from `ModelExporter.export()` method signature
- **Removed `export_from_workspace()` method** - its functionality is now the primary `export()` method
- **Updated implementation** to call `ir.workspace.export()` directly instead of accepting workspace as a parameter
- **Updated all documentation** in README, docstrings, and examples to reflect the new API
- **Simplified usage pattern** - users now call `exporter.export(ir, window_config, split_config)` instead of `exporter.export(workspace, ir, ...)`

## Implementation Details
The change maintains the same underlying delegation to `workspace.export()`, but shifts the responsibility to the caller to ensure the IR is linked to a workspace before calling export. This is a cleaner API since:
1. IRs are typically loaded from a workspace via `workspace.load()`, so they're already linked
2. It eliminates the redundancy of passing both workspace and IR
3. It reduces the API surface from two methods to one

The error handling now validates that `ir.workspace` is not None, providing a clear error message if the IR isn't properly linked.

https://claude.ai/code/session_019xbaCm69pKAbBqMZvao64F