### PR TITLE
Update README dataset list with NYISO, MelPeds, and NYT COVID

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ print(ir.metadata.transform_history)
 | PEMS04 | 307 | Flow, Occupancy, Speed | 5 min | CalTrans |
 | PEMS08 | 170 | Flow, Occupancy, Speed | 5 min | CalTrans |
 | Elergone | 370 | Power | 15 min | UCI ML Repository |
+| NYISO Integrated Load | 11 | Load | 1 hour | NYISO |
+| Melbourne Pedestrian Counts | 55 | Count | 1 hour | UCTB Urban Dataset |
+| NYT COVID-19 (US Counties) | 3,000+ | Cases, Deaths | 1 day | The New York Times |
 
 ### Loading Datasets
 
@@ -164,6 +167,9 @@ from gnn_benchmark.datasets import (
     PEMS04Loader,
     PEMS08Loader,
     ElergoneLoader,
+    NYISOLoader,
+    MelPedsLoader,
+    NYCovidLoader,
 )
 
 # Example: Load Beijing Air with different subdivisions


### PR DESCRIPTION
### Motivation
- Keep the project documentation in `README.md` aligned with the dataset loaders already present in the codebase by documenting newly available data sources.
- Provide users with a concise summary of the newly supported datasets (NYISO, Melbourne Pedestrian Counts, NYT COVID-19) so they can discover and load them easily.

### Description
- Updated the `README.md` `Available Datasets` table to add entries for `NYISO Integrated Load`, `Melbourne Pedestrian Counts`, and `NYT COVID-19 (US Counties)`.
- Updated the `Loading Datasets` import example in `README.md` to include `NYISOLoader`, `MelPedsLoader`, and `NYCovidLoader` so the example matches the actual loaders present.

### Testing
- No automated tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9480e7f08320b09e30b3ad93ba98)