### PR TITLE
Add BenchmarkRunner and model submission contract for GNN evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,154 @@ print(f"Per-horizon metrics: {result.per_horizon_metrics}")
 | HistoricalAverage | Predicts average from same period in history |
 | SARIMA | Seasonal ARIMA with optional Kalman imputation |
 
+## Model Submission Contract
+
+To benchmark a custom GNN model, subclass `BenchmarkModel` and implement
+`fit` and `predict`.
+
+```python
+from gnn_benchmark.models import BenchmarkModel, TrainingHistory
+
+class MyGNN(BenchmarkModel):
+    name = "MyGNN"
+
+    def fit(self, train_loader, val_loader, adj, config):
+        """
+        Train the model.
+
+        Args:
+            train_loader: DataLoader yielding (x_batch, y_batch) with
+                          x_batch [B, seq_in_len, N, D_in] float32
+                          y_batch [B, seq_out_len, N, D_out] float32
+            val_loader:   Same format, shuffle=False.
+            adj:          Adjacency matrix [N, N] float32, or None if the
+                          dataset has no edge information.
+            config:       Any config object you choose (dataclass, dict, …).
+        """
+        # ... train your model ...
+        return TrainingHistory(train_loss=[...], val_loss=[...])  # or None
+
+    def predict(self, test_loader, adj, config):
+        """
+        Generate predictions.
+
+        Returns:
+            np.ndarray of shape [num_test_samples, seq_out_len, N, D_out]
+            in the same normalised space as the training targets.
+        """
+        # ... run inference ...
+        return y_pred
+
+    def get_config(self) -> dict:
+        """Optional: expose hyperparameters for result logging."""
+        return {"hidden_dim": 64, "layers": 3}
+```
+
+### Contract rules
+
+| Rule | Detail |
+|------|--------|
+| **DataLoader format** | Loaders yield `(x_batch, y_batch)` float32 tensors |
+| **Test order** | `test_loader` is always `shuffle=False` — row order matches ground truth |
+| **Adjacency** | `adj` is `None` for datasets with no graph; raise `ValueError` if you require it |
+| **Normalisation** | Inputs and targets are Z-score normalised; return `y_pred` in the same space |
+| **Config** | Fully submitter-controlled — pass whatever your model needs |
+
+### Building DataLoaders manually
+
+```python
+from gnn_benchmark.exporters import create_sliding_windows, split_by_time, make_dataloaders
+from gnn_benchmark.exporters import WindowConfig, SplitConfig
+
+data = ir.to_tensor()                            # (T, N, C)
+x, y = create_sliding_windows(data, input_length=12, horizon=12)
+x_train, x_val, x_test = split_by_time(x, 0.7, 0.1)
+y_train, y_val, y_test = split_by_time(y, 0.7, 0.1)
+
+train_loader, val_loader, test_loader = make_dataloaders(
+    x_train, y_train, x_val, y_val, x_test, y_test, batch_size=32
+)
+```
+
+---
+
+## Running the Benchmark
+
+`BenchmarkRunner` drives the full pipeline — download, preprocess, window,
+fit, predict, and score — for every dataset you specify.
+
+```python
+from benchmark import BenchmarkRunner
+from gnn_benchmark.exporters import WindowConfig, SplitConfig
+
+runner = BenchmarkRunner(
+    workspace_dir="./benchmark_workspace",
+    datasets=["metr-la", "pems-bay", "pems04"],  # None = all datasets
+    window_config=WindowConfig(input_length=12, horizon=12),
+    split_config=SplitConfig(train_ratio=0.7, val_ratio=0.1),
+    batch_size=32,
+)
+
+result = runner.run(MyGNN(), config=my_config)
+print(result.summary())
+```
+
+Sample output:
+
+```
+Model: MyGNN
+────────────────────────────────────────────────────────
+Dataset              MAE      RMSE     MAPE
+────────────────────────────────────────────────────────
+metr-la           0.4123   0.6814   9.21%
+pems-bay          0.3187   0.5241   7.83%
+pems04            0.5214   0.8427  11.40%
+────────────────────────────────────────────────────────
+Mean              0.4175   0.6827   9.48%
+────────────────────────────────────────────────────────
+(metrics in normalised space)
+```
+
+### Available datasets
+
+| Key | Dataset |
+|-----|---------|
+| `metr-la` | METR-LA (requires `gdown`) |
+| `pems-bay` | PEMS-BAY (requires `gdown`) |
+| `pems04` | PEMS04 |
+| `pems08` | PEMS08 |
+| `beijing-air` | Beijing Air Quality |
+| `elergone` | Elergone (no graph) |
+| `nyiso` | NYISO Integrated Load (no graph) |
+| `nyc-covid` | NYT COVID-19 US Counties |
+| `mel-peds` | Melbourne Pedestrian Counts |
+
+### Accessing detailed results
+
+```python
+# Per-dataset metrics
+r = result.dataset_results["metr-la"]
+print(r.mae, r.rmse, r.mape)
+
+# Per-horizon breakdown
+for step, metrics in r.per_horizon.items():
+    print(f"  step {step:2d}: MAE={metrics['mae']:.4f}")
+
+# Export to dict / JSON
+import json
+print(json.dumps(result.to_dict(), indent=2))
+```
+
+### Adding PyTorch
+
+The `make_dataloaders` helper and the benchmark runner require PyTorch:
+
+```bash
+pip install torch
+```
+
+---
+
 ## Utility Functions
 
 ### Evaluation Metrics

--- a/__init__.py
+++ b/__init__.py
@@ -47,6 +47,7 @@ from gnn_benchmark import transforms
 from gnn_benchmark import exporters
 from gnn_benchmark import baselines
 from gnn_benchmark import utils
+from gnn_benchmark import models
 
 __all__ = [
     # Version
@@ -62,4 +63,5 @@ __all__ = [
     "exporters",
     "baselines",
     "utils",
+    "models",
 ]

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,402 @@
+"""
+Full end-to-end benchmark runner for GNN model submissions.
+
+Usage
+-----
+::
+
+    from benchmark import BenchmarkRunner
+    from gnn_benchmark.models import BenchmarkModel, TrainingHistory
+    from gnn_benchmark.exporters import WindowConfig, SplitConfig
+
+    class MyGNN(BenchmarkModel):
+        name = "MyGNN"
+
+        def fit(self, train_loader, val_loader, adj, config):
+            ...  # train your model
+            return None
+
+        def predict(self, test_loader, adj, config):
+            ...  # return np.ndarray [num_test_samples, seq_out_len, N, D_out]
+
+    runner = BenchmarkRunner(
+        workspace_dir="./benchmark_workspace",
+        datasets=["metr-la", "pems-bay"],        # None = all datasets
+        window_config=WindowConfig(input_length=12, horizon=12),
+    )
+    result = runner.run(MyGNN(), config=my_config)
+    print(result.summary())
+
+Pipeline (per dataset)
+----------------------
+1.  Prepare IR  — download and cache via ``DataWorkspace``
+2.  Transform   — ``FillZeros`` then ``ZScoreNormalize`` (train split only)
+3.  Window      — sliding windows → ``(x, y)`` arrays via ``create_sliding_windows``
+4.  Split       — temporal train / val / test via ``split_by_time``
+5.  DataLoaders — ``make_dataloaders`` (test loader always ``shuffle=False``)
+6.  Fit         — ``model.fit(train_loader, val_loader, adj, config)``
+7.  Predict     — ``model.predict(test_loader, adj, config)``
+8.  Metrics     — MAE, RMSE, MAPE in normalised space
+
+Notes
+-----
+- Metrics are computed in the **normalised space** (after ``ZScoreNormalize``).
+  Raw-unit metrics can be derived by the caller using ``ir.metadata.extra``
+  (keys ``zscore_means`` / ``zscore_stds``).
+- ``adj`` is ``None`` for datasets that carry no edge information.
+- ``config`` is passed through unchanged; the runner does not inspect it.
+"""
+
+from __future__ import annotations
+
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from gnn_benchmark.core.workspace import DataWorkspace
+from gnn_benchmark.datasets import (
+    BeijingAirLoader,
+    ElergoneLoader,
+    MetroLALoader,
+    MelPedsLoader,
+    NYCovidLoader,
+    NYISOLoader,
+    PEMS04Loader,
+    PEMS08Loader,
+    PEMSBayLoader,
+)
+from gnn_benchmark.exporters import WindowConfig, SplitConfig
+from gnn_benchmark.exporters.dataloader import (
+    create_sliding_windows,
+    make_dataloaders,
+    split_by_time,
+)
+from gnn_benchmark.models import BenchmarkModel
+from gnn_benchmark.transforms import FillZeros, ZScoreNormalize
+from gnn_benchmark.utils.metrics import mae, mape, rmse
+
+
+# ---------------------------------------------------------------------------
+# Dataset registry
+# ---------------------------------------------------------------------------
+
+DATASET_REGISTRY: dict[str, Any] = {
+    "metr-la":    MetroLALoader,
+    "pems-bay":   PEMSBayLoader,
+    "pems04":     PEMS04Loader,
+    "pems08":     PEMS08Loader,
+    "beijing-air": BeijingAirLoader,
+    "elergone":   ElergoneLoader,
+    "nyiso":      NYISOLoader,
+    "nyc-covid":  NYCovidLoader,
+    "mel-peds":   MelPedsLoader,
+}
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DatasetResult:
+    """
+    Benchmark metrics for a single dataset.
+
+    Attributes:
+        dataset_name: Registry key of the dataset.
+        mae:          Mean Absolute Error (normalised space).
+        rmse:         Root Mean Squared Error (normalised space).
+        mape:         Mean Absolute Percentage Error (normalised space, 0–100 scale).
+        per_horizon:  Per-step metrics ``{step: {"mae": ..., "rmse": ..., "mape": ...}}``.
+                      ``None`` when ``horizon == 1``.
+        error:        Exception message if this dataset failed; other fields are ``None``.
+    """
+
+    dataset_name: str
+    mae: float | None = None
+    rmse: float | None = None
+    mape: float | None = None
+    per_horizon: dict[int, dict[str, float]] | None = None
+    error: str | None = None
+
+
+@dataclass
+class BenchmarkResult:
+    """
+    Aggregated results returned by ``BenchmarkRunner.run()``.
+
+    Attributes:
+        model_name:      Value of ``BenchmarkModel.name``.
+        model_config:    Dict returned by ``BenchmarkModel.get_config()``.
+        dataset_results: Mapping from dataset key to ``DatasetResult``.
+    """
+
+    model_name: str
+    model_config: dict = field(default_factory=dict)
+    dataset_results: dict[str, DatasetResult] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    def summary(self) -> str:
+        """
+        Return a formatted table of results.
+
+        Datasets that failed are shown with ``ERROR`` instead of metric values.
+        An aggregate row shows the mean across successful datasets.
+        """
+        lines: list[str] = []
+        sep = "─" * 56
+        lines.append(f"\nModel: {self.model_name}")
+        lines.append(sep)
+        lines.append(f"{'Dataset':<20} {'MAE':>8} {'RMSE':>8} {'MAPE':>8}")
+        lines.append(sep)
+
+        mae_vals, rmse_vals, mape_vals = [], [], []
+
+        for name, r in self.dataset_results.items():
+            if r.error:
+                lines.append(f"{name:<20} {'ERROR':>8}   {r.error[:24]}")
+            else:
+                lines.append(
+                    f"{name:<20} {r.mae:>8.4f} {r.rmse:>8.4f} {r.mape:>7.2f}%"
+                )
+                mae_vals.append(r.mae)
+                rmse_vals.append(r.rmse)
+                mape_vals.append(r.mape)
+
+        if mae_vals:
+            lines.append(sep)
+            lines.append(
+                f"{'Mean':<20} {np.mean(mae_vals):>8.4f}"
+                f" {np.mean(rmse_vals):>8.4f}"
+                f" {np.mean(mape_vals):>7.2f}%"
+            )
+
+        lines.append(sep)
+        lines.append("(metrics in normalised space)")
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        """Return a plain-dict representation suitable for JSON serialisation."""
+        return {
+            "model_name": self.model_name,
+            "model_config": self.model_config,
+            "datasets": {
+                name: {
+                    "mae": r.mae,
+                    "rmse": r.rmse,
+                    "mape": r.mape,
+                    "per_horizon": r.per_horizon,
+                    "error": r.error,
+                }
+                for name, r in self.dataset_results.items()
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+class BenchmarkRunner:
+    """
+    Drives the full benchmark pipeline for one or more datasets.
+
+    Args:
+        workspace_dir: Directory used by ``DataWorkspace`` for caching.
+                       Created automatically if it does not exist.
+        datasets:      List of dataset keys from ``DATASET_REGISTRY`` to
+                       benchmark against.  ``None`` runs all registered datasets.
+        window_config: Sliding window parameters (input length, horizon, …).
+        split_config:  Temporal train / val / test ratios.
+        batch_size:    Batch size forwarded to ``make_dataloaders``.
+        verbose:       Print progress messages when ``True``.
+    """
+
+    def __init__(
+        self,
+        workspace_dir: str | Path = "./benchmark_workspace",
+        datasets: list[str] | None = None,
+        window_config: WindowConfig | None = None,
+        split_config: SplitConfig | None = None,
+        batch_size: int = 32,
+        verbose: bool = True,
+    ) -> None:
+        self.workspace_dir = Path(workspace_dir)
+        self.window_config = window_config or WindowConfig()
+        self.split_config = split_config or SplitConfig()
+        self.batch_size = batch_size
+        self.verbose = verbose
+
+        if datasets is None:
+            self.datasets = list(DATASET_REGISTRY.keys())
+        else:
+            unknown = set(datasets) - set(DATASET_REGISTRY)
+            if unknown:
+                raise ValueError(
+                    f"Unknown dataset(s): {unknown}. "
+                    f"Available: {list(DATASET_REGISTRY)}"
+                )
+            self.datasets = datasets
+
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        model: BenchmarkModel,
+        config: Any = None,
+    ) -> BenchmarkResult:
+        """
+        Run the full benchmark for all configured datasets.
+
+        For each dataset the runner:
+        1. Prepares the IR (download + cache).
+        2. Applies ``FillZeros`` and ``ZScoreNormalize`` (train-split stats).
+        3. Creates sliding windows and temporal splits.
+        4. Builds DataLoaders (test loader always ``shuffle=False``).
+        5. Calls ``model.fit(train_loader, val_loader, adj, config)``.
+        6. Calls ``model.predict(test_loader, adj, config)``.
+        7. Computes MAE, RMSE, MAPE and per-horizon metrics.
+
+        Dataset failures are caught and recorded in ``DatasetResult.error``
+        so that a single broken dataset does not abort the full run.
+
+        Args:
+            model:  A fitted or unfitted ``BenchmarkModel`` instance.
+            config: Opaque config object forwarded to ``fit`` and ``predict``.
+
+        Returns:
+            ``BenchmarkResult`` with per-dataset and aggregate metrics.
+        """
+        result = BenchmarkResult(
+            model_name=model.name,
+            model_config=model.get_config(),
+        )
+
+        workspace = DataWorkspace(self.workspace_dir)
+
+        for dataset_key in self.datasets:
+            self._log(f"\n[{dataset_key}] Starting …")
+            try:
+                dr = self._run_dataset(workspace, dataset_key, model, config)
+            except Exception as exc:  # noqa: BLE001
+                dr = DatasetResult(
+                    dataset_name=dataset_key,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+                if self.verbose:
+                    traceback.print_exc()
+
+            result.dataset_results[dataset_key] = dr
+            if dr.error:
+                self._log(f"[{dataset_key}] FAILED — {dr.error}")
+            else:
+                self._log(
+                    f"[{dataset_key}] Done  "
+                    f"MAE={dr.mae:.4f}  RMSE={dr.rmse:.4f}  MAPE={dr.mape:.2f}%"
+                )
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run_dataset(
+        self,
+        workspace: DataWorkspace,
+        dataset_key: str,
+        model: BenchmarkModel,
+        config: Any,
+    ) -> DatasetResult:
+        wc = self.window_config
+        sc = self.split_config
+
+        # 1. Prepare IR
+        loader_cls = DATASET_REGISTRY[dataset_key]
+        loader = loader_cls()
+        self._log(f"[{dataset_key}] Preparing data …")
+        ir = loader.prepare(workspace)
+
+        # 2. Standard transforms
+        self._log(f"[{dataset_key}] Applying transforms …")
+        train_end, _ = ir.get_split_timestamps(sc.train_ratio, sc.val_ratio)
+        ir.apply(FillZeros())
+        ir.apply(ZScoreNormalize(train_end=train_end))
+
+        # 3. Build tensor and select columns
+        x_cols = wc.input_columns  # None → all features
+        y_cols = wc.target_columns or x_cols
+
+        x_data = ir.to_tensor(x_cols)  # (T, N, D_in)
+        y_data = ir.to_tensor(y_cols)  # (T, N, D_out)
+
+        # 4. Sliding windows
+        self._log(f"[{dataset_key}] Windowing …")
+        x_all, _ = create_sliding_windows(x_data, wc.input_length, wc.horizon, wc.y_start)
+        _, y_all = create_sliding_windows(y_data, wc.input_length, wc.horizon, wc.y_start)
+
+        # 5. Temporal split
+        x_train, x_val, x_test = split_by_time(x_all, sc.train_ratio, sc.val_ratio)
+        y_train, y_val, y_test = split_by_time(y_all, sc.train_ratio, sc.val_ratio)
+
+        # 6. DataLoaders
+        train_loader, val_loader, test_loader = make_dataloaders(
+            x_train, y_train,
+            x_val,   y_val,
+            x_test,  y_test,
+            batch_size=self.batch_size,
+        )
+
+        # 7. Adjacency
+        adj = ir.get_adjacency_matrix() if ir.edges is not None else None
+
+        # 8. Fit
+        self._log(f"[{dataset_key}] Fitting model …")
+        model.fit(train_loader, val_loader, adj, config)
+
+        # 9. Predict
+        self._log(f"[{dataset_key}] Predicting …")
+        y_pred = model.predict(test_loader, adj, config)
+        y_pred = np.asarray(y_pred)
+
+        # Validate output shape
+        expected = y_test.shape
+        if y_pred.shape != expected:
+            raise ValueError(
+                f"predict() returned shape {y_pred.shape}, expected {expected}. "
+                "y_pred must be [num_test_samples, seq_out_len, N, D_out]."
+            )
+
+        # 10. Metrics (overall)
+        dataset_mae  = mae(y_test,  y_pred)
+        dataset_rmse = rmse(y_test, y_pred)
+        dataset_mape = mape(y_test, y_pred)
+
+        # 11. Per-horizon metrics
+        horizon = wc.horizon
+        per_horizon: dict[int, dict[str, float]] | None = None
+        if horizon > 1:
+            per_horizon = {}
+            for h in range(horizon):
+                yt_h = y_test[:, h, :, :]
+                yp_h = y_pred[:, h, :, :]
+                per_horizon[h + 1] = {
+                    "mae":  mae(yt_h,  yp_h),
+                    "rmse": rmse(yt_h, yp_h),
+                    "mape": mape(yt_h, yp_h),
+                }
+
+        return DatasetResult(
+            dataset_name=dataset_key,
+            mae=dataset_mae,
+            rmse=dataset_rmse,
+            mape=dataset_mape,
+            per_horizon=per_horizon,
+        )
+
+    def _log(self, msg: str) -> None:
+        if self.verbose:
+            print(msg)

--- a/exporters/__init__.py
+++ b/exporters/__init__.py
@@ -44,6 +44,11 @@ from gnn_benchmark.exporters.astgcn import ASTGCNExporter
 from gnn_benchmark.exporters.mtgnn import MTGNNExporter
 from gnn_benchmark.exporters.gts import GTSExporter
 from gnn_benchmark.exporters.d2stgcn import D2STGCNExporter
+from gnn_benchmark.exporters.dataloader import (
+    create_sliding_windows,
+    split_by_time,
+    make_dataloaders,
+)
 
 __all__ = [
     "ModelExporter",
@@ -56,4 +61,7 @@ __all__ = [
     "MTGNNExporter",
     "GTSExporter",
     "D2STGCNExporter",
+    "create_sliding_windows",
+    "split_by_time",
+    "make_dataloaders",
 ]

--- a/exporters/base.py
+++ b/exporters/base.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from gnn_benchmark.exporters.dataloader import (
+    create_sliding_windows as _create_sliding_windows_fn,
+    split_by_time as _split_by_time_fn,
+)
+
 if TYPE_CHECKING:
     from gnn_benchmark.core.intermediate import IntermediateRepresentation
 
@@ -192,41 +197,7 @@ class ModelExporter(ABC):
             - y: Array of shape (S, H, N, C) - target windows
             S = number of valid samples
         """
-        T = data.shape[0]
-
-        # Ensure 3D
-        if data.ndim == 2:
-            data = data[:, :, np.newaxis]
-
-        # Calculate number of valid samples
-        # For each sample i, we need:
-        # - Input: data[i:i+L]
-        # - Target: data[i+L+y_start-1:i+L+y_start-1+H]
-        # Last valid i: i+L+y_start-1+H-1 < T => i < T - L - y_start - H + 2
-        num_samples = T - input_length - y_start - horizon + 2
-
-        if num_samples <= 0:
-            raise ValueError(
-                f"Not enough data for windowing. T={T}, L={input_length}, "
-                f"H={horizon}, y_start={y_start}"
-            )
-
-        x_list = []
-        y_list = []
-
-        for i in range(num_samples):
-            x_start = i
-            x_end = i + input_length
-            y_start_idx = x_end + y_start - 1
-            y_end_idx = y_start_idx + horizon
-
-            x_list.append(data[x_start:x_end])
-            y_list.append(data[y_start_idx:y_end_idx])
-
-        x = np.stack(x_list, axis=0)  # (S, L, N, C)
-        y = np.stack(y_list, axis=0)  # (S, H, N, C)
-
-        return x, y
+        return _create_sliding_windows_fn(data, input_length, horizon, y_start)
 
     def _split_by_time(
         self,
@@ -245,11 +216,7 @@ class ModelExporter(ABC):
         Returns:
             (train, val, test) arrays
         """
-        n = data.shape[0]
-        train_end = int(n * train_ratio)
-        val_end = int(n * (train_ratio + val_ratio))
-
-        return data[:train_end], data[train_end:val_end], data[val_end:]
+        return _split_by_time_fn(data, train_ratio, val_ratio)
 
     def _compute_offsets(
         self, input_length: int, horizon: int, y_start: int = 1

--- a/exporters/dataloader.py
+++ b/exporters/dataloader.py
@@ -1,0 +1,157 @@
+"""
+Windowing helpers and DataLoader builder for the GNN Benchmark.
+
+This module exposes:
+- ``create_sliding_windows``: Convert a (T, N, C) array into (S, L, N, C) / (S, H, N, C) pairs.
+- ``split_by_time``: Split the first dimension of an array into train / val / test.
+- ``make_dataloaders``: Wrap numpy arrays into PyTorch DataLoaders ready for ``BenchmarkModel``.
+
+``ModelExporter`` delegates its helper methods to these functions so that
+the benchmark runner can reuse the same logic without going through an exporter.
+"""
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+try:
+    import torch
+    from torch.utils.data import DataLoader, TensorDataset
+    _TORCH_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _TORCH_AVAILABLE = False
+
+if TYPE_CHECKING:
+    from torch.utils.data import DataLoader  # noqa: F811
+
+
+# ---------------------------------------------------------------------------
+# Windowing
+# ---------------------------------------------------------------------------
+
+def create_sliding_windows(
+    data: np.ndarray,
+    input_length: int,
+    horizon: int,
+    y_start: int = 1,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Create sliding input/target windows from a time series array.
+
+    Args:
+        data:         Array of shape ``(T, N, C)`` or ``(T, N)``.
+        input_length: Number of past timesteps ``L`` in each input window.
+        horizon:      Number of future timesteps ``H`` in each target window.
+        y_start:      Gap between the last input step and the first target step.
+                      Default ``1`` means targets start immediately after inputs.
+
+    Returns:
+        ``(x, y)`` where
+
+        * ``x`` has shape ``(S, L, N, C)``  — input windows
+        * ``y`` has shape ``(S, H, N, C)``  — target windows
+        * ``S = T - input_length - y_start - horizon + 2``
+
+    Raises:
+        ValueError: If there is not enough data to create at least one window.
+    """
+    if data.ndim == 2:
+        data = data[:, :, np.newaxis]
+
+    T = data.shape[0]
+    num_samples = T - input_length - y_start - horizon + 2
+
+    if num_samples <= 0:
+        raise ValueError(
+            f"Not enough data for windowing. "
+            f"T={T}, input_length={input_length}, horizon={horizon}, y_start={y_start}"
+        )
+
+    x_list, y_list = [], []
+    for i in range(num_samples):
+        x_end = i + input_length
+        y_start_idx = x_end + y_start - 1
+        x_list.append(data[i:x_end])
+        y_list.append(data[y_start_idx : y_start_idx + horizon])
+
+    return np.stack(x_list, axis=0), np.stack(y_list, axis=0)
+
+
+def split_by_time(
+    data: np.ndarray,
+    train_ratio: float,
+    val_ratio: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Split an array temporally into train / val / test portions.
+
+    The split is performed on the first dimension (samples / time steps).
+    Temporal order is preserved: ``train → val → test``.
+
+    Args:
+        data:        Array whose first dimension represents time / samples.
+        train_ratio: Fraction of samples for training.
+        val_ratio:   Fraction of samples for validation.
+
+    Returns:
+        ``(train, val, test)`` sub-arrays.
+    """
+    n = data.shape[0]
+    train_end = int(n * train_ratio)
+    val_end = int(n * (train_ratio + val_ratio))
+    return data[:train_end], data[train_end:val_end], data[val_end:]
+
+
+# ---------------------------------------------------------------------------
+# DataLoader builder
+# ---------------------------------------------------------------------------
+
+def make_dataloaders(
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    x_val: np.ndarray,
+    y_val: np.ndarray,
+    x_test: np.ndarray,
+    y_test: np.ndarray,
+    batch_size: int = 32,
+    shuffle_train: bool = True,
+) -> "tuple[DataLoader, DataLoader, DataLoader]":
+    """
+    Wrap pre-windowed numpy arrays into PyTorch DataLoaders.
+
+    All arrays are cast to ``float32`` before wrapping.  The test loader is
+    **always** created with ``shuffle=False`` to guarantee that prediction
+    rows align with ground-truth rows in the same order.
+
+    Args:
+        x_train:       Training inputs  ``[S_train, L, N, D_in]``.
+        y_train:       Training targets ``[S_train, H, N, D_out]``.
+        x_val:         Validation inputs  ``[S_val, L, N, D_in]``.
+        y_val:         Validation targets ``[S_val, H, N, D_out]``.
+        x_test:        Test inputs  ``[S_test, L, N, D_in]``.
+        y_test:        Test targets ``[S_test, H, N, D_out]``.
+        batch_size:    Batch size for all loaders.
+        shuffle_train: Whether to shuffle the training loader (default ``True``).
+
+    Returns:
+        ``(train_loader, val_loader, test_loader)``
+
+    Raises:
+        ImportError: If PyTorch is not installed.
+    """
+    if not _TORCH_AVAILABLE:
+        raise ImportError(
+            "PyTorch is required for make_dataloaders. "
+            "Install it with: pip install torch"
+        )
+
+    def _to_loader(x: np.ndarray, y: np.ndarray, shuffle: bool) -> "DataLoader":
+        tx = torch.from_numpy(x.astype(np.float32))
+        ty = torch.from_numpy(y.astype(np.float32))
+        return DataLoader(TensorDataset(tx, ty), batch_size=batch_size, shuffle=shuffle)
+
+    train_loader = _to_loader(x_train, y_train, shuffle=shuffle_train)
+    val_loader   = _to_loader(x_val,   y_val,   shuffle=False)
+    test_loader  = _to_loader(x_test,  y_test,  shuffle=False)
+
+    return train_loader, val_loader, test_loader

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,30 @@
+"""
+Model submission contract for GNN Benchmark.
+
+To submit a model for benchmarking, subclass ``BenchmarkModel`` and implement
+``fit`` and ``predict``.  Then pass your model instance to
+``BenchmarkRunner.run()``.
+
+Example::
+
+    from gnn_benchmark.models import BenchmarkModel, TrainingHistory
+
+    class MyGNN(BenchmarkModel):
+        name = "MyGNN"
+
+        def fit(self, train_loader, val_loader, adj, config):
+            # Train your model here
+            ...
+            return TrainingHistory(train_loss=[...], val_loss=[...])
+
+        def predict(self, test_loader, adj, config):
+            # Return np.ndarray of shape [num_test_samples, seq_out_len, N, D_out]
+            ...
+"""
+
+from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
+
+__all__ = [
+    "BenchmarkModel",
+    "TrainingHistory",
+]

--- a/models/base.py
+++ b/models/base.py
@@ -1,0 +1,127 @@
+"""Abstract base class for GNN model submissions to the benchmark."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+try:
+    from torch.utils.data import DataLoader
+except ImportError:  # pragma: no cover
+    DataLoader = Any  # type: ignore[misc,assignment]
+
+
+@dataclass
+class TrainingHistory:
+    """
+    Training history returned by BenchmarkModel.fit().
+
+    Attributes:
+        train_loss: Loss value recorded after each training epoch.
+        val_loss: Loss value recorded after each validation epoch.
+    """
+
+    train_loss: list[float]
+    val_loss: list[float]
+
+
+class BenchmarkModel(ABC):
+    """
+    Contract for model submissions to the GNN benchmark.
+
+    A submission must implement ``fit`` and ``predict``.  The harness
+    (``BenchmarkRunner``) calls them in sequence for every dataset and
+    collects the returned predictions for metric computation.
+
+    DataLoader contract
+    -------------------
+    Both loaders yield ``(x_batch, y_batch)`` 2-tuples of float32 tensors:
+
+    .. code-block::
+
+        x_batch : [B, seq_in_len,  N, D_in]
+        y_batch : [B, seq_out_len, N, D_out]
+
+    The ``test_loader`` passed to ``predict`` is always created with
+    ``shuffle=False`` by ``make_dataloaders``, which guarantees that
+    ``y_pred`` rows correspond one-to-one with the ground-truth ``y_test``
+    rows in the order they were windowed.
+
+    Adjacency matrix
+    ----------------
+    ``adj`` is a float32 ``(N, N)`` numpy array whose row/column order
+    matches the node dimension ``N`` in ``x`` and ``y``.  It is ``None``
+    for datasets that carry no edge information.  A model that requires
+    a graph should raise ``ValueError("adj is required")`` when called
+    with ``adj=None``.
+
+    Normalisation contract
+    ----------------------
+    ``x`` and ``y`` arriving in the DataLoaders are already in the
+    normalised space produced by the preprocessing pipeline
+    (``ZScoreNormalize`` by default).  ``y_pred`` must be returned in
+    the **same normalised space**.  The harness handles denormalisation
+    before computing human-readable metrics.
+
+    Config
+    ------
+    ``config`` is fully submitter-controlled — pass whatever object your
+    model needs (a dataclass, a dict, ``None``, …).  Implement
+    ``get_config()`` to expose it for result logging.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable model name used in result tables."""
+
+    @abstractmethod
+    def fit(
+        self,
+        train_loader: "DataLoader",
+        val_loader: "DataLoader",
+        adj: np.ndarray | None,
+        config: Any,
+    ) -> "TrainingHistory | None":
+        """
+        Train the model.
+
+        Args:
+            train_loader: DataLoader over training windows (shuffle=True).
+            val_loader:   DataLoader over validation windows (shuffle=False).
+            adj:          Adjacency matrix [N, N] or None.
+            config:       Submitter-defined configuration object.
+
+        Returns:
+            TrainingHistory if the model tracks per-epoch losses, else None.
+        """
+
+    @abstractmethod
+    def predict(
+        self,
+        test_loader: "DataLoader",
+        adj: np.ndarray | None,
+        config: Any,
+    ) -> np.ndarray:
+        """
+        Generate predictions for all test windows.
+
+        Args:
+            test_loader: DataLoader over test windows (shuffle=False, order preserved).
+            adj:         Adjacency matrix [N, N] or None.
+            config:      Submitter-defined configuration object.
+
+        Returns:
+            y_pred : np.ndarray of shape [num_test_samples, seq_out_len, N, D_out]
+                     in the same normalised space as the training targets.
+        """
+
+    def get_config(self) -> dict:
+        """
+        Return a serialisable representation of the model's configuration.
+
+        Override this to expose hyperparameters in benchmark result logs.
+        The default implementation returns an empty dict.
+        """
+        return {}


### PR DESCRIPTION
## Summary

This PR introduces a complete end-to-end benchmarking framework for evaluating GNN models across multiple datasets. It includes:

1. **BenchmarkRunner** — a harness that orchestrates the full pipeline (data prep, preprocessing, windowing, fitting, prediction, and metric computation) for one or more datasets
2. **BenchmarkModel** — an abstract base class defining the submission contract for custom GNN models
3. **Dataloader utilities** — extracted windowing and DataLoader creation logic into a reusable module

## Key Changes

- **`benchmark.py`** (new)
  - `BenchmarkRunner` class that drives the full benchmark pipeline per dataset
  - `BenchmarkResult` and `DatasetResult` dataclasses for aggregating and reporting metrics
  - Dataset registry mapping keys to loader classes
  - Per-horizon metric computation for multi-step forecasting
  - Graceful error handling so one dataset failure doesn't abort the full run

- **`models/base.py`** (new)
  - `BenchmarkModel` abstract base class with `fit()` and `predict()` contract
  - `TrainingHistory` dataclass for optional loss tracking
  - Comprehensive docstrings documenting DataLoader format, adjacency matrix handling, normalisation contract, and config expectations

- **`models/__init__.py`** (new)
  - Public API for model submission contract

- **`exporters/dataloader.py`** (new)
  - `create_sliding_windows()` — converts (T, N, C) time series into (S, L, N, C) / (S, H, N, C) window pairs
  - `split_by_time()` — temporal train/val/test split preserving order
  - `make_dataloaders()` — wraps numpy arrays into PyTorch DataLoaders with proper shuffle semantics (test always `shuffle=False`)

- **`exporters/base.py`** (modified)
  - Refactored `_create_sliding_windows()` and `_split_by_time()` to delegate to the new dataloader module functions, eliminating code duplication

- **`exporters/__init__.py`** (modified)
  - Exported `create_sliding_windows`, `split_by_time`, and `make_dataloaders` for public use

- **`README.md`** (modified)
  - Added "Model Submission Contract" section with example implementation
  - Added "Running the Benchmark" section with usage examples and sample output
  - Documented available datasets and how to access detailed results

- **`__init__.py`** (modified)
  - Added `models` module to package exports

## Notable Implementation Details

- **Error resilience**: Dataset failures are caught and recorded in `DatasetResult.error` so the benchmark continues for remaining datasets
- **Test order preservation**: The test DataLoader is always created with `shuffle=False` to guarantee prediction rows align with ground-truth rows
- **Per-horizon metrics**: When `horizon > 1`, the runner computes MAE/RMSE/MAPE for each forecast step separately
- **Normalisation contract**: All metrics are computed in normalised space; raw-unit metrics can be derived using `ir.metadata.extra` (zscore_means/stds)
- **Flexible config**: The `config` parameter is fully submitter-controlled and passed through unchanged to `fit()` and `predict()`

https://claude.ai/code/session_0128nUNkXdKgxM5xrXpWHJ34