### PR TITLE
Add LastValueModel toy model and comprehensive end-to-end tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ list_of_models.txt
 /models_prep/testingtxt.py
 /models_prep/testingpickle.py
 __pycache__/
+*.egg-info/
+.eggs/

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,27 @@
+"""
+Pytest configuration for the GNN Benchmark test suite.
+
+The repo directory is named ``GNN_Benchmark`` but all source imports use the
+package name ``gnn_benchmark``.  A symlink at ``/home/user/gnn_benchmark``
+pointing to this directory makes the package importable; the parent directory
+is added to ``sys.path`` here so both ``benchmark.py`` and ``gnn_benchmark``
+are discoverable.
+
+To set up the symlink (one-time, already in place in the dev environment)::
+
+    ln -sf /path/to/GNN_Benchmark /path/to/gnn_benchmark
+"""
+
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).parent.resolve()   # /home/user/GNN_Benchmark
+_parent = _repo_root.parent                    # /home/user/
+
+# benchmark.py lives at the repo root
+if str(_repo_root) not in sys.path:
+    sys.path.insert(0, str(_repo_root))
+
+# gnn_benchmark symlink lives one level up
+if str(_parent) not in sys.path:
+    sys.path.insert(0, str(_parent))

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -23,8 +23,10 @@ Example::
 """
 
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
+from gnn_benchmark.models.last_value import LastValueModel
 
 __all__ = [
     "BenchmarkModel",
     "TrainingHistory",
+    "LastValueModel",
 ]

--- a/models/last_value.py
+++ b/models/last_value.py
@@ -1,0 +1,73 @@
+"""Last-value (persistence) toy model for end-to-end pipeline testing."""
+
+from typing import Any
+
+import numpy as np
+
+from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
+
+
+class LastValueModel(BenchmarkModel):
+    """
+    Last-value persistence model for smoke-testing the benchmark pipeline.
+
+    For every test window it forecasts the final observed value of the input
+    window for all horizon steps:
+
+        y_hat(t+1) = y_hat(t+2) = … = y_hat(t+H) = x(t)
+
+    The model requires no training.  Its deterministic predictions make it
+    easy to verify metric correctness in end-to-end tests.
+    """
+
+    def __init__(self) -> None:
+        self._horizon: int | None = None
+
+    @property
+    def name(self) -> str:
+        return "LastValue"
+
+    def fit(
+        self,
+        x_train: Any,
+        y_train: Any,
+        x_val: Any,
+        y_val: Any,
+        adj: np.ndarray | None,
+        config: Any,
+        norm_stats: dict | None = None,
+    ) -> TrainingHistory | None:
+        """No-op: store horizon length inferred from training targets."""
+        self._horizon = y_train.shape[1]
+        return None
+
+    def predict(
+        self,
+        x_test: Any,
+        adj: np.ndarray | None,
+        config: Any,
+    ) -> np.ndarray:
+        """
+        Repeat the last input timestep for each forecast horizon step.
+
+        Args:
+            x_test: ``[S, L, N, D]`` input windows (torch.Tensor or ndarray).
+            adj:    Ignored.
+            config: Ignored.
+
+        Returns:
+            ``np.ndarray`` of shape ``[S, H, N, D]`` where every horizon step
+            equals the final value of the corresponding input window.
+        """
+        if self._horizon is None:
+            raise RuntimeError("Call fit() before predict().")
+
+        # Extract last timestep: [S, N, D]
+        last = x_test[:, -1, :, :]
+        if hasattr(last, "numpy"):
+            last = last.numpy()
+        else:
+            last = np.asarray(last)
+
+        # Tile along a new horizon axis: [S, 1, N, D] -> [S, H, N, D]
+        return np.repeat(last[:, np.newaxis, :, :], self._horizon, axis=1)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+# Add the repo root (for benchmark.py) and its parent (for the gnn_benchmark
+# symlink) to sys.path so tests can import both without extra setup.
+pythonpath = . ..

--- a/tests/test_e2e_benchmark.py
+++ b/tests/test_e2e_benchmark.py
@@ -1,0 +1,218 @@
+"""End-to-end tests for the benchmark pipeline using the LastValueModel toy model.
+
+These tests validate the full pipeline:
+    SyntheticLoader → DataWorkspace → sliding windows → temporal split
+    → LastValueModel.fit() → LastValueModel.predict() → metrics
+
+No network access is required; all data is generated in-memory.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+# Ensure the repo root is importable when running tests directly
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from benchmark import BenchmarkRunner  # noqa: E402
+from gnn_benchmark.core.types import DatasetInfo  # noqa: E402
+from gnn_benchmark.datasets.base import DatasetLoader  # noqa: E402
+from gnn_benchmark.exporters import SplitConfig, WindowConfig  # noqa: E402
+from gnn_benchmark.models import LastValueModel  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Synthetic dataset (no network access)
+# ---------------------------------------------------------------------------
+
+class SyntheticLoader(DatasetLoader):
+    """Generates deterministic in-memory data for pipeline testing.
+
+    Three nodes, 200 hourly timesteps.  Feature ``value[t] = float(t)`` for
+    all nodes.  With a horizon of H the last-value model produces error = h
+    at step h, so per-horizon MAEs are [1, 2, 3, …, H].
+    """
+
+    N_NODES = 3
+    N_TIMESTAMPS = 200
+
+    @property
+    def info(self) -> DatasetInfo:
+        return DatasetInfo(
+            name="synthetic",
+            url="",
+            frequency="1H",
+            node_order=[f"n{i}" for i in range(self.N_NODES)],
+            feature_columns=["value"],
+        )
+
+    def download_and_convert(
+        self,
+    ) -> tuple[pd.DataFrame, pd.DataFrame | None]:
+        timestamps = pd.date_range(
+            "2024-01-01", periods=self.N_TIMESTAMPS, freq="1h"
+        )
+        rows = [
+            {"ts": ts, "node_id": f"n{i}", "value": float(t)}
+            for t, ts in enumerate(timestamps)
+            for i in range(self.N_NODES)
+        ]
+        return pd.DataFrame(rows), None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — LastValueModel in isolation
+# ---------------------------------------------------------------------------
+
+class TestLastValueModel:
+    """Unit tests that do not touch the pipeline at all."""
+
+    def _fit(self, model: LastValueModel, S: int, L: int, H: int, N: int, D: int):
+        x = torch.randn(S, L, N, D)
+        y = torch.randn(S, H, N, D)
+        history = model.fit(x, y, x, y, adj=None, config=None)
+        return x, history
+
+    def test_fit_returns_none(self):
+        model = LastValueModel()
+        _, history = self._fit(model, S=50, L=6, H=4, N=3, D=2)
+        assert history is None
+
+    def test_predict_shape(self):
+        model = LastValueModel()
+        S, L, H, N, D = 50, 6, 4, 3, 2
+        self._fit(model, S=S, L=L, H=H, N=N, D=D)
+
+        x_test = torch.randn(20, L, N, D)
+        y_pred = model.predict(x_test, adj=None, config=None)
+
+        assert isinstance(y_pred, np.ndarray)
+        assert y_pred.shape == (20, H, N, D)
+
+    def test_predict_repeats_last_value(self):
+        """Every horizon step must equal x_test[:, -1, :, :]."""
+        model = LastValueModel()
+        S, L, H, N, D = 30, 8, 5, 2, 1
+        self._fit(model, S=S, L=L, H=H, N=N, D=D)
+
+        x_test = torch.randn(10, L, N, D)
+        y_pred = model.predict(x_test, adj=None, config=None)
+
+        last_values = x_test[:, -1, :, :].numpy()  # [10, N, D]
+        for h in range(H):
+            np.testing.assert_array_equal(
+                y_pred[:, h, :, :],
+                last_values,
+                err_msg=f"Mismatch at horizon step {h}",
+            )
+
+    def test_predict_without_fit_raises(self):
+        model = LastValueModel()
+        x_test = torch.randn(5, 4, 3, 1)
+        with pytest.raises(RuntimeError, match="fit"):
+            model.predict(x_test, adj=None, config=None)
+
+    def test_name(self):
+        assert LastValueModel().name == "LastValue"
+
+    def test_get_config_returns_dict(self):
+        assert isinstance(LastValueModel().get_config(), dict)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pipeline test
+# ---------------------------------------------------------------------------
+
+class TestE2EBenchmarkPipeline:
+    """Full pipeline: SyntheticLoader → BenchmarkRunner → metrics."""
+
+    INPUT_LENGTH = 6
+    HORIZON = 6
+
+    @pytest.fixture()
+    def runner(self, tmp_path: Path) -> BenchmarkRunner:
+        with patch.dict("benchmark.DATASET_REGISTRY", {"synthetic": SyntheticLoader}):
+            yield BenchmarkRunner(
+                workspace_dir=tmp_path / "ws",
+                datasets=["synthetic"],
+                window_config=WindowConfig(
+                    input_length=self.INPUT_LENGTH,
+                    horizon=self.HORIZON,
+                ),
+                split_config=SplitConfig(train_ratio=0.7, val_ratio=0.1),
+                verbose=False,
+            )
+
+    def test_no_error(self, runner: BenchmarkRunner):
+        result = runner.run(LastValueModel(), config=None)
+        dr = result.dataset_results["synthetic"]
+        assert dr.error is None, f"Pipeline raised an error: {dr.error}"
+
+    def test_model_name_in_result(self, runner: BenchmarkRunner):
+        result = runner.run(LastValueModel(), config=None)
+        assert result.model_name == "LastValue"
+
+    def test_metrics_are_finite(self, runner: BenchmarkRunner):
+        result = runner.run(LastValueModel(), config=None)
+        dr = result.dataset_results["synthetic"]
+        assert np.isfinite(dr.mae),  f"MAE is not finite: {dr.mae}"
+        assert np.isfinite(dr.rmse), f"RMSE is not finite: {dr.rmse}"
+        assert np.isfinite(dr.mape), f"MAPE is not finite: {dr.mape}"
+
+    def test_mae_is_positive(self, runner: BenchmarkRunner):
+        """Persistence on linearly increasing data must have MAE > 0."""
+        result = runner.run(LastValueModel(), config=None)
+        dr = result.dataset_results["synthetic"]
+        assert dr.mae > 0
+
+    def test_per_horizon_count(self, runner: BenchmarkRunner):
+        result = runner.run(LastValueModel(), config=None)
+        dr = result.dataset_results["synthetic"]
+        assert dr.per_horizon is not None
+        assert len(dr.per_horizon) == self.HORIZON
+
+    def test_per_horizon_mae_increases_with_step(self, runner: BenchmarkRunner):
+        """On linear data (value[t]=t) the error at step h equals h, so
+        per-horizon MAEs must be strictly increasing.
+        """
+        result = runner.run(LastValueModel(), config=None)
+        dr = result.dataset_results["synthetic"]
+        maes = [dr.per_horizon[h]["mae"] for h in range(1, self.HORIZON + 1)]
+        for i in range(len(maes) - 1):
+            assert maes[i] < maes[i + 1], (
+                f"Expected per-horizon MAE to increase: step {i+1}={maes[i]:.4f} "
+                f"≥ step {i+2}={maes[i+1]:.4f}"
+            )
+
+    def test_per_horizon_mae_values(self, runner: BenchmarkRunner):
+        """On linear data the MAE at horizon step h equals exactly h."""
+        result = runner.run(LastValueModel(), config=None)
+        dr = result.dataset_results["synthetic"]
+        for step in range(1, self.HORIZON + 1):
+            expected = float(step)
+            actual = dr.per_horizon[step]["mae"]
+            assert abs(actual - expected) < 1e-4, (
+                f"Step {step}: expected MAE={expected}, got {actual:.6f}"
+            )
+
+    def test_summary_runs_without_error(self, runner: BenchmarkRunner):
+        result = runner.run(LastValueModel(), config=None)
+        summary = result.summary()
+        assert "LastValue" in summary
+        assert "synthetic" in summary
+
+    def test_to_dict_serialisable(self, runner: BenchmarkRunner):
+        import json
+        result = runner.run(LastValueModel(), config=None)
+        data = result.to_dict()
+        # Should serialise to JSON without error
+        json.dumps(data)
+        assert data["model_name"] == "LastValue"
+        assert "synthetic" in data["datasets"]


### PR DESCRIPTION
## Summary
This PR introduces a simple persistence (last-value) model and a comprehensive end-to-end test suite to validate the full benchmark pipeline without requiring network access or external datasets.

## Key Changes

- **New `LastValueModel` class** (`models/last_value.py`):
  - Implements a deterministic persistence baseline that repeats the final input timestep for all forecast horizon steps
  - Requires no actual training (fit is a no-op that only stores horizon length)
  - Provides predictable, verifiable predictions for testing metric correctness
  - Useful as a smoke-test baseline for the benchmark pipeline

- **Comprehensive end-to-end test suite** (`tests/test_e2e_benchmark.py`):
  - `SyntheticLoader`: In-memory synthetic dataset generator (3 nodes, 200 hourly timesteps with linearly increasing values)
  - `TestLastValueModel`: Unit tests validating the model in isolation (fit/predict behavior, shape correctness, error handling)
  - `TestE2EBenchmarkPipeline`: Full pipeline tests covering:
    - Data loading → windowing → temporal split → model training → prediction → metric computation
    - Metric validity (finiteness, positivity)
    - Per-horizon metric correctness (MAE increases linearly with horizon step on synthetic data)
    - Result serialization and summary generation

- **Test infrastructure**:
  - `conftest.py`: Pytest configuration handling sys.path setup for both `benchmark.py` and `gnn_benchmark` package imports
  - `pytest.ini`: Centralized pythonpath configuration
  - Updated `models/__init__.py` to export `LastValueModel`
  - Updated `.gitignore` to exclude egg-info and .eggs directories

## Notable Implementation Details

- The synthetic dataset generates deterministic data where `value[t] = float(t)`, making per-horizon MAE predictions mathematically verifiable (MAE at step h equals exactly h)
- Tests use `unittest.mock.patch` to inject the synthetic loader into the dataset registry without modifying production code
- All tests run without network access or external dependencies
- The model correctly handles both torch.Tensor and numpy.ndarray inputs via `hasattr` checks

https://claude.ai/code/session_01VGLMkAf5MRiYh6q1h1qqdC