### PR TITLE
Add Beijing air quality cluster datasets to registry

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -74,6 +74,8 @@ except ImportError:  # pragma: no cover
 from gnn_benchmark.core.workspace import DataWorkspace
 from gnn_benchmark.datasets import (
     BeijingAirLoader,
+    Cluster1AirLoader,
+    Cluster2AirLoader,
     ElergoneLoader,
     MetroLALoader,
     MelPedsLoader,
@@ -97,15 +99,17 @@ from gnn_benchmark.utils.metrics import mae, mape, rmse
 # ---------------------------------------------------------------------------
 
 DATASET_REGISTRY: dict[str, Any] = {
-    "metr-la":    MetroLALoader,
-    "pems-bay":   PEMSBayLoader,
-    "pems04":     PEMS04Loader,
-    "pems08":     PEMS08Loader,
-    "beijing-air": BeijingAirLoader,
-    "elergone":   ElergoneLoader,
-    "nyiso":      NYISOLoader,
-    "nyc-covid":  NYCovidLoader,
-    "mel-peds":   MelPedsLoader,
+    "metr-la":              MetroLALoader,
+    "pems-bay":             PEMSBayLoader,
+    "pems04":               PEMS04Loader,
+    "pems08":               PEMS08Loader,
+    "beijing-air":          BeijingAirLoader,
+    "beijing-air-cluster1": Cluster1AirLoader,
+    "beijing-air-cluster2": Cluster2AirLoader,
+    "elergone":             ElergoneLoader,
+    "nyiso":                NYISOLoader,
+    "nyc-covid":            NYCovidLoader,
+    "mel-peds":             MelPedsLoader,
 }
 
 


### PR DESCRIPTION
## Summary
This PR adds support for two new Beijing air quality cluster datasets to the benchmark framework by registering them in the dataset registry.

## Key Changes
- Added imports for `Cluster1AirLoader` and `Cluster2AirLoader` dataset loaders
- Registered two new datasets in `DATASET_REGISTRY`:
  - `"beijing-air-cluster1"` → `Cluster1AirLoader`
  - `"beijing-air-cluster2"` → `Cluster2AirLoader`
- Reformatted the dataset registry dictionary with consistent alignment for improved readability

## Implementation Details
The new cluster datasets are variants of the Beijing air quality dataset, allowing benchmarking on partitioned subsets of the data. The registry entries follow the existing naming convention and are positioned logically after the base Beijing air dataset entry.

https://claude.ai/code/session_01CP5CAYXpz1owxkoiLbbhKk