### PR TITLE
Fix metric calculation to exclude NaN values in predictions

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -374,8 +374,8 @@ class BenchmarkRunner:
                 "y_pred must be [num_test_samples, seq_out_len, N, D_out]."
             )
 
-        # 9. Metrics (original units; exclude positions where ground truth is NaN)
-        valid_mask = ~np.isnan(y_test)
+        # 9. Metrics (original units; exclude NaN in ground truth or predictions)
+        valid_mask = ~np.isnan(y_test) & ~np.isnan(y_pred)
         dataset_mae  = mae(y_test,  y_pred, mask=valid_mask)
         dataset_rmse = rmse(y_test, y_pred, mask=valid_mask)
         dataset_mape = mape(y_test, y_pred, mask=valid_mask)
@@ -388,7 +388,7 @@ class BenchmarkRunner:
             for h in range(horizon):
                 yt_h = y_test[:, h, :, :]
                 yp_h = y_pred[:, h, :, :]
-                mask_h = ~np.isnan(yt_h)
+                mask_h = ~np.isnan(yt_h) & ~np.isnan(yp_h)
                 per_horizon[h + 1] = {
                     "mae":  mae(yt_h,  yp_h, mask=mask_h),
                     "rmse": rmse(yt_h, yp_h, mask=mask_h),


### PR DESCRIPTION
## Summary
Updated metric calculation logic to properly handle NaN values in both ground truth and prediction data, ensuring invalid predictions don't skew benchmark results.

## Key Changes
- Modified the valid data mask to exclude NaN values from both `y_test` and `y_pred`, not just ground truth
  - Updated dataset-level metrics mask: `~np.isnan(y_test) & ~np.isnan(y_pred)`
  - Updated per-horizon metrics mask: `~np.isnan(yt_h) & ~np.isnan(yp_h)`
- Updated comment to clarify that NaN values are excluded from both ground truth and predictions

## Implementation Details
Previously, the valid mask only checked for NaN values in the ground truth (`y_test`), which could allow NaN predictions to be included in metric calculations. This change ensures that any sample with NaN in either the ground truth or prediction is excluded from the metrics (MAE, RMSE, MAPE), providing more accurate benchmark results.

https://claude.ai/code/session_01QtXrvRPVWcrVFYMNZPaC7H