### PR TITLE
Add Beijing Air examples for all trainable benchmark models

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ print(result.summary())
 
 See [`examples/basic_example.py`](examples/basic_example.py) for a runnable example.
 
+Model-specific Beijing Air examples (including config overrides):
+- [`examples/beijing_air_gwn_example.py`](examples/beijing_air_gwn_example.py)
+- [`examples/beijing_air_mtgnn_example.py`](examples/beijing_air_mtgnn_example.py)
+- [`examples/beijing_air_staeformer_example.py`](examples/beijing_air_staeformer_example.py)
+- [`examples/beijing_air_d2stgnn_example.py`](examples/beijing_air_d2stgnn_example.py)
+
 ## Model Contract
 
 Subclass `BenchmarkModel` and implement `fit` and `predict`:

--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -7,6 +7,12 @@ This script demonstrates the full GNN Benchmark workflow:
 2. Run a model (LastValueModel) through the benchmark
 3. Print the evaluation results
 
+For trainable model + config examples on Beijing Air, see:
+- examples/beijing_air_gwn_example.py
+- examples/beijing_air_mtgnn_example.py
+- examples/beijing_air_staeformer_example.py
+- examples/beijing_air_d2stgnn_example.py
+
 Usage:
     python examples/basic_example.py
 """

--- a/examples/beijing_air_d2stgnn_example.py
+++ b/examples/beijing_air_d2stgnn_example.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Run D2STGNN on the Beijing Air dataset.
+
+Usage:
+    python examples/beijing_air_d2stgnn_example.py
+"""
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
+
+runner = BenchmarkRunner(
+    workspace_dir="./benchmark_workspace",
+    datasets=["beijing-air"],
+)
+
+# Override only the config values you want to tune for your run.
+config = D2STGNNConfig(
+    max_epochs=20,
+    batch_size=32,
+    lr=0.002,
+    early_stop=10,
+)
+
+result = runner.run(D2STGNNModel(), config=config)
+print(result.summary())

--- a/examples/beijing_air_gwn_example.py
+++ b/examples/beijing_air_gwn_example.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Run Graph WaveNet on the Beijing Air dataset.
+
+Usage:
+    python examples/beijing_air_gwn_example.py
+"""
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import GWNConfig, GWNModel
+
+runner = BenchmarkRunner(
+    workspace_dir="./benchmark_workspace",
+    datasets=["beijing-air"],
+)
+
+# Override only the config values you want to tune for your run.
+config = GWNConfig(
+    max_epochs=20,
+    batch_size=32,
+    lr=0.001,
+    early_stop=10,
+)
+
+result = runner.run(GWNModel(), config=config)
+print(result.summary())

--- a/examples/beijing_air_mtgnn_example.py
+++ b/examples/beijing_air_mtgnn_example.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Run MTGNN on the Beijing Air dataset.
+
+Usage:
+    python examples/beijing_air_mtgnn_example.py
+"""
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import MTGNNConfig, MTGNNModel
+
+runner = BenchmarkRunner(
+    workspace_dir="./benchmark_workspace",
+    datasets=["beijing-air"],
+)
+
+# Override only the config values you want to tune for your run.
+config = MTGNNConfig(
+    max_epochs=20,
+    batch_size=32,
+    lr=0.001,
+    early_stop=10,
+)
+
+result = runner.run(MTGNNModel(), config=config)
+print(result.summary())

--- a/examples/beijing_air_staeformer_example.py
+++ b/examples/beijing_air_staeformer_example.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Run STAEFormer on the Beijing Air dataset.
+
+Usage:
+    python examples/beijing_air_staeformer_example.py
+"""
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
+
+runner = BenchmarkRunner(
+    workspace_dir="./benchmark_workspace",
+    datasets=["beijing-air"],
+)
+
+# Override only the config values you want to tune for your run.
+config = STAEFormerConfig(
+    max_epochs=20,
+    batch_size=16,
+    lr=0.001,
+    early_stop=10,
+)
+
+result = runner.run(STAEFormerModel(), config=config)
+print(result.summary())


### PR DESCRIPTION
### Motivation
- Provide clear, runnable examples showing how to run each trainable benchmark model on the `beijing-air` dataset and how to pass model-specific config objects to `runner.run(..., config=...)`.
- Make it easier for users to find model-specific quick-starts from the top-level docs and the basic example.

### Description
- Added four new example scripts under `examples/` demonstrating a single-model run on `beijing-air` with a small, overridable config: `beijing_air_gwn_example.py` (GWNModel + `GWNConfig`).
- Added `beijing_air_mtgnn_example.py` (MTGNNModel + `MTGNNConfig`), `beijing_air_staeformer_example.py` (STAEFormerModel + `STAEFormerConfig`), and `beijing_air_d2stgnn_example.py` (D2STGNNModel + `D2STGNNConfig`).
- Updated `examples/basic_example.py` docstring to point to the new model-specific Beijing Air examples.
- Updated `README.md` Quick Start section to link the four new examples and note that they include config overrides for easy tuning.

### Testing
- Compiled the example scripts with `python -m compileall examples`, which completed successfully.
- No changes were made to unit tests or core functionality; the compile step verifies the new examples are syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d777c805b88320b98c407944d14ad4)