### PR TITLE
Add hyperparameter tuning framework with grid/random search

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -112,6 +112,43 @@ DATASET_REGISTRY: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 
 @dataclass
+class PreparedDataset:
+    """
+    Windowed, split, tensorised tensors for a single dataset.
+
+    Produced by :meth:`BenchmarkRunner.prepare_dataset` and consumed both
+    by the runner itself (for ``fit`` + ``predict`` + metrics) and by the
+    hyperparameter tuner (``fit`` only — the test tensors are ignored
+    during tuning so the held-out set is never leaked).
+
+    Attributes:
+        dataset_name: Registry key of the dataset.
+        x_train:      Training inputs  ``[S_train, seq_in_len, N, D_in]``,
+                      NaN = missing.
+        y_train:      Training targets ``[S_train, seq_out_len, N, D_out]``.
+        x_val:        Validation inputs.
+        y_val:        Validation targets.
+        x_test:       Test inputs (used only for final evaluation).
+        y_test:       Test targets as a raw numpy array (used only for
+                      final metric computation).
+        adj:          Adjacency matrix ``[N, N]`` or ``None``.
+        window_config: The ``WindowConfig`` the splits were built with.
+        split_config:  The ``SplitConfig`` the splits were built with.
+    """
+
+    dataset_name: str
+    x_train: "torch.Tensor"
+    y_train: "torch.Tensor"
+    x_val: "torch.Tensor"
+    y_val: "torch.Tensor"
+    x_test: "torch.Tensor"
+    y_test: np.ndarray
+    adj: np.ndarray | None
+    window_config: Any
+    split_config: Any
+
+
+@dataclass
 class DatasetResult:
     """
     Benchmark metrics for a single dataset.
@@ -342,13 +379,29 @@ class BenchmarkRunner:
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _run_dataset(
+    def prepare_dataset(
         self,
         workspace: DataWorkspace,
         dataset_key: str,
-        model: BenchmarkModel,
-        config: Any,
-    ) -> DatasetResult:
+    ) -> PreparedDataset:
+        """
+        Download, window, split, and tensorise a single dataset.
+
+        This is the deterministic data-prep portion of the benchmark pipeline
+        extracted into a reusable helper.  Both ``_run_dataset`` and the
+        hyperparameter tuner call it; the splits they see are therefore
+        guaranteed to be identical.
+
+        The returned :class:`PreparedDataset` carries all six tensors plus
+        the adjacency and config metadata.  Consumers that should not see the
+        test set (i.e. the tuner) simply ignore ``x_test`` / ``y_test``.
+        """
+        if dataset_key not in DATASET_REGISTRY:
+            raise ValueError(
+                f"Unknown dataset: {dataset_key!r}. "
+                f"Available: {list(DATASET_REGISTRY)}"
+            )
+
         # 1. Prepare IR (raw data, NaN for missing values — no imputation applied)
         loader_cls = DATASET_REGISTRY[dataset_key]
         loader = loader_cls()
@@ -385,14 +438,42 @@ class BenchmarkRunner:
         # 6. Adjacency
         adj = ir.get_adjacency_matrix() if ir.edges is not None else None
 
+        return PreparedDataset(
+            dataset_name=dataset_key,
+            x_train=x_train_t,
+            y_train=y_train_t,
+            x_val=x_val_t,
+            y_val=y_val_t,
+            x_test=x_test_t,
+            y_test=y_test,
+            adj=adj,
+            window_config=wc,
+            split_config=sc,
+        )
+
+    def _run_dataset(
+        self,
+        workspace: DataWorkspace,
+        dataset_key: str,
+        model: BenchmarkModel,
+        config: Any,
+    ) -> DatasetResult:
+        prepared = self.prepare_dataset(workspace, dataset_key)
+
         # 7. Fit
         self._log(f"[{dataset_key}] Fitting model …")
-        model.fit(x_train_t, y_train_t, x_val_t, y_val_t, adj, config)
+        model.fit(
+            prepared.x_train, prepared.y_train,
+            prepared.x_val, prepared.y_val,
+            prepared.adj, config,
+        )
 
         # 8. Predict
         self._log(f"[{dataset_key}] Predicting …")
-        y_pred = model.predict(x_test_t, adj, config)
+        y_pred = model.predict(prepared.x_test, prepared.adj, config)
         y_pred = np.asarray(y_pred)
+
+        y_test = prepared.y_test
 
         # Validate output shape
         expected = y_test.shape
@@ -403,7 +484,7 @@ class BenchmarkRunner:
             )
 
         # 9. Per-horizon metrics (always computed)
-        horizon = wc.horizon
+        horizon = prepared.window_config.horizon
         per_horizon: dict[int, dict[str, float]] = {}
         for h in range(horizon):
             yt_h = y_test[:, h, :, :]

--- a/examples/beijing_air_d2stgnn_example.py
+++ b/examples/beijing_air_d2stgnn_example.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run D2STGNN on the Beijing Air dataset.
+"""Tune D2STGNN on the Beijing Air dataset, then report test metrics.
+
+Pipeline:
+    1. Run a small grid search over D2STGNN-specific hyperparameters, scored
+       by validation loss.  The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline once
+       for an unbiased test-set evaluation.
 
 Usage:
     python examples/beijing_air_d2stgnn_example.py
@@ -7,19 +13,37 @@ Usage:
 
 from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
 
-runner = BenchmarkRunner(
-    workspace_dir="./benchmark_workspace",
-    datasets=["beijing-air"],
-)
+WORKSPACE = "./benchmark_workspace"
+DATASET = "beijing-air"
 
-# Override only the config values you want to tune for your run.
-config = D2STGNNConfig(
-    max_epochs=20,
+base_config = D2STGNNConfig(
+    max_epochs=10,
     batch_size=32,
-    lr=0.002,
-    early_stop=10,
+    early_stop=5,
 )
 
-result = runner.run(D2STGNNModel(), config=config)
-print(result.summary())
+# D2STGNN-specific search space (2x2 grid = 4 trials).
+# - lr         : D2STGNN's default (2e-3) is higher than GWN/MTGNN
+# - num_hidden : hidden channel width — the main capacity knob
+tuner = HyperparameterTuner(
+    model_factory=lambda: D2STGNNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":         Categorical([2e-3, 1e-3]),
+        "num_hidden": Categorical([16, 32]),
+    },
+    strategy="grid",
+)
+tuning_result = tuner.run()
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(D2STGNNModel(), config=tuning_result.best.config)
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/beijing_air_d2stgnn_example.py
+++ b/examples/beijing_air_d2stgnn_example.py
@@ -2,10 +2,13 @@
 """Tune D2STGNN on the Beijing Air dataset, then report test metrics.
 
 Pipeline:
-    1. Run a small grid search over D2STGNN-specific hyperparameters, scored
-       by validation loss.  The test set is NOT seen during this phase.
+    1. Run a grid search over D2STGNN-specific hyperparameters, scored by
+       validation loss.  The test set is NOT seen during this phase.
     2. Take the winning config and run the standard benchmark pipeline once
        for an unbiased test-set evaluation.
+
+Grid is 2 x 3 x 3 = 18 trials.  Each trial performs a full fit() on
+Beijing Air, so the total cost is ~18x a single training run.
 
 Usage:
     python examples/beijing_air_d2stgnn_example.py
@@ -24,9 +27,10 @@ base_config = D2STGNNConfig(
     early_stop=5,
 )
 
-# D2STGNN-specific search space (2x2 grid = 4 trials).
+# D2STGNN-specific search space (2 x 3 x 3 = 18 trials).
 # - lr         : D2STGNN's default (2e-3) is higher than GWN/MTGNN
 # - num_hidden : hidden channel width — the main capacity knob
+# - dropout    : regularisation; D2STGNN uses a lower default (0.1)
 tuner = HyperparameterTuner(
     model_factory=lambda: D2STGNNModel(),
     base_config=base_config,
@@ -34,7 +38,8 @@ tuner = HyperparameterTuner(
     workspace_dir=WORKSPACE,
     search_space={
         "lr":         Categorical([2e-3, 1e-3]),
-        "num_hidden": Categorical([16, 32]),
+        "num_hidden": Categorical([16, 32, 64]),
+        "dropout":    Categorical([0.1, 0.2, 0.3]),
     },
     strategy="grid",
 )

--- a/examples/beijing_air_gwn_example.py
+++ b/examples/beijing_air_gwn_example.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run Graph WaveNet on the Beijing Air dataset.
+"""Tune Graph WaveNet on the Beijing Air dataset, then report test metrics.
+
+Pipeline:
+    1. Run a small grid search over GWN-specific hyperparameters, scored by
+       validation loss.  The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline once
+       for an unbiased test-set evaluation.
 
 Usage:
     python examples/beijing_air_gwn_example.py
@@ -7,19 +13,39 @@ Usage:
 
 from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import GWNConfig, GWNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
 
-runner = BenchmarkRunner(
-    workspace_dir="./benchmark_workspace",
-    datasets=["beijing-air"],
-)
+WORKSPACE = "./benchmark_workspace"
+DATASET = "beijing-air"
 
-# Override only the config values you want to tune for your run.
-config = GWNConfig(
-    max_epochs=20,
+# Shared base config — fields not listed in the search space use these values.
+base_config = GWNConfig(
+    max_epochs=10,
     batch_size=32,
-    lr=0.001,
-    early_stop=10,
+    early_stop=5,
 )
 
-result = runner.run(GWNModel(), config=config)
-print(result.summary())
+# GWN-specific search space (2x2 grid = 4 trials).
+# - lr         : training signal
+# - dropout    : regularisation; GWN has 2 spatio-temporal blocks and can overfit
+tuner = HyperparameterTuner(
+    model_factory=lambda: GWNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":      Categorical([1e-3, 5e-4]),
+        "dropout": Categorical([0.1, 0.3]),
+    },
+    strategy="grid",
+)
+tuning_result = tuner.run()
+print(tuning_result.summary())
+
+# Final, unbiased test-set evaluation with the winning config.
+if tuning_result.best is not None:
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(GWNModel(), config=tuning_result.best.config)
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/beijing_air_gwn_example.py
+++ b/examples/beijing_air_gwn_example.py
@@ -2,10 +2,14 @@
 """Tune Graph WaveNet on the Beijing Air dataset, then report test metrics.
 
 Pipeline:
-    1. Run a small grid search over GWN-specific hyperparameters, scored by
+    1. Run a grid search over GWN-specific hyperparameters, scored by
        validation loss.  The test set is NOT seen during this phase.
     2. Take the winning config and run the standard benchmark pipeline once
        for an unbiased test-set evaluation.
+
+Grid is 2 x 3 x 3 = 18 trials.  Each trial performs a full fit() on
+Beijing Air, so the total cost is ~18x a single training run — run on a
+GPU host if you have one.
 
 Usage:
     python examples/beijing_air_gwn_example.py
@@ -25,9 +29,12 @@ base_config = GWNConfig(
     early_stop=5,
 )
 
-# GWN-specific search space (2x2 grid = 4 trials).
-# - lr         : training signal
-# - dropout    : regularisation; GWN has 2 spatio-temporal blocks and can overfit
+# GWN-specific search space (2 x 3 x 3 = 18 trials).
+# Covers the three knobs that move GWN performance most on small
+# spatiotemporal datasets:
+# - lr      : training signal (log-scale pair)
+# - dropout : regularisation — GWN stacks 4 blocks and overfits easily
+# - nhid    : hidden channel width — the main capacity knob
 tuner = HyperparameterTuner(
     model_factory=lambda: GWNModel(),
     base_config=base_config,
@@ -35,7 +42,8 @@ tuner = HyperparameterTuner(
     workspace_dir=WORKSPACE,
     search_space={
         "lr":      Categorical([1e-3, 5e-4]),
-        "dropout": Categorical([0.1, 0.3]),
+        "dropout": Categorical([0.1, 0.3, 0.5]),
+        "nhid":    Categorical([16, 32, 64]),
     },
     strategy="grid",
 )

--- a/examples/beijing_air_mtgnn_example.py
+++ b/examples/beijing_air_mtgnn_example.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run MTGNN on the Beijing Air dataset.
+"""Tune MTGNN on the Beijing Air dataset, then report test metrics.
+
+Pipeline:
+    1. Run a small grid search over MTGNN-specific hyperparameters, scored
+       by validation loss.  The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline once
+       for an unbiased test-set evaluation.
 
 Usage:
     python examples/beijing_air_mtgnn_example.py
@@ -7,19 +13,37 @@ Usage:
 
 from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import MTGNNConfig, MTGNNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
 
-runner = BenchmarkRunner(
-    workspace_dir="./benchmark_workspace",
-    datasets=["beijing-air"],
-)
+WORKSPACE = "./benchmark_workspace"
+DATASET = "beijing-air"
 
-# Override only the config values you want to tune for your run.
-config = MTGNNConfig(
-    max_epochs=20,
+base_config = MTGNNConfig(
+    max_epochs=10,
     batch_size=32,
-    lr=0.001,
-    early_stop=10,
+    early_stop=5,
 )
 
-result = runner.run(MTGNNModel(), config=config)
-print(result.summary())
+# MTGNN-specific search space (2x2 grid = 4 trials).
+# - lr            : training signal
+# - conv_channels : width of the core TCN/GCN stack — the main capacity knob
+tuner = HyperparameterTuner(
+    model_factory=lambda: MTGNNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":            Categorical([1e-3, 5e-4]),
+        "conv_channels": Categorical([16, 32]),
+    },
+    strategy="grid",
+)
+tuning_result = tuner.run()
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(MTGNNModel(), config=tuning_result.best.config)
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/beijing_air_mtgnn_example.py
+++ b/examples/beijing_air_mtgnn_example.py
@@ -2,10 +2,13 @@
 """Tune MTGNN on the Beijing Air dataset, then report test metrics.
 
 Pipeline:
-    1. Run a small grid search over MTGNN-specific hyperparameters, scored
-       by validation loss.  The test set is NOT seen during this phase.
+    1. Run a grid search over MTGNN-specific hyperparameters, scored by
+       validation loss.  The test set is NOT seen during this phase.
     2. Take the winning config and run the standard benchmark pipeline once
        for an unbiased test-set evaluation.
+
+Grid is 2 x 3 x 3 = 18 trials.  Each trial performs a full fit() on
+Beijing Air, so the total cost is ~18x a single training run.
 
 Usage:
     python examples/beijing_air_mtgnn_example.py
@@ -24,9 +27,14 @@ base_config = MTGNNConfig(
     early_stop=5,
 )
 
-# MTGNN-specific search space (2x2 grid = 4 trials).
-# - lr            : training signal
+# MTGNN-specific search space (2 x 3 x 3 = 18 trials).
+# - lr            : training signal (log-scale pair)
 # - conv_channels : width of the core TCN/GCN stack — the main capacity knob
+# - dropout       : regularisation
+#
+# Note: residual_channels is left at its default (32) for all trials.  The
+# MTGNN blocks already support a mismatch between conv_channels and
+# residual_channels, so we only vary conv_channels here.
 tuner = HyperparameterTuner(
     model_factory=lambda: MTGNNModel(),
     base_config=base_config,
@@ -34,7 +42,8 @@ tuner = HyperparameterTuner(
     workspace_dir=WORKSPACE,
     search_space={
         "lr":            Categorical([1e-3, 5e-4]),
-        "conv_channels": Categorical([16, 32]),
+        "conv_channels": Categorical([16, 32, 64]),
+        "dropout":       Categorical([0.1, 0.3, 0.5]),
     },
     strategy="grid",
 )

--- a/examples/beijing_air_staeformer_example.py
+++ b/examples/beijing_air_staeformer_example.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Run STAEFormer on the Beijing Air dataset.
+"""Tune STAEFormer on the Beijing Air dataset, then report test metrics.
+
+Pipeline:
+    1. Run a small grid search over STAEFormer-specific hyperparameters,
+       scored by validation loss.  The test set is NOT seen during this
+       phase.
+    2. Take the winning config and run the standard benchmark pipeline
+       once for an unbiased test-set evaluation.
 
 Usage:
     python examples/beijing_air_staeformer_example.py
@@ -7,19 +14,37 @@ Usage:
 
 from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
 
-runner = BenchmarkRunner(
-    workspace_dir="./benchmark_workspace",
-    datasets=["beijing-air"],
-)
+WORKSPACE = "./benchmark_workspace"
+DATASET = "beijing-air"
 
-# Override only the config values you want to tune for your run.
-config = STAEFormerConfig(
-    max_epochs=20,
+base_config = STAEFormerConfig(
+    max_epochs=10,
     batch_size=16,
-    lr=0.001,
-    early_stop=10,
+    early_stop=5,
 )
 
-result = runner.run(STAEFormerModel(), config=config)
-print(result.summary())
+# STAEFormer-specific search space (2x2 grid = 4 trials).
+# - lr         : training signal
+# - num_layers : transformer depth — the main capacity knob for STAEFormer
+tuner = HyperparameterTuner(
+    model_factory=lambda: STAEFormerModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":         Categorical([1e-3, 5e-4]),
+        "num_layers": Categorical([2, 3]),
+    },
+    strategy="grid",
+)
+tuning_result = tuner.run()
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(STAEFormerModel(), config=tuning_result.best.config)
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/beijing_air_staeformer_example.py
+++ b/examples/beijing_air_staeformer_example.py
@@ -2,11 +2,19 @@
 """Tune STAEFormer on the Beijing Air dataset, then report test metrics.
 
 Pipeline:
-    1. Run a small grid search over STAEFormer-specific hyperparameters,
-       scored by validation loss.  The test set is NOT seen during this
-       phase.
+    1. Run a grid search over STAEFormer-specific hyperparameters, scored
+       by validation loss.  The test set is NOT seen during this phase.
     2. Take the winning config and run the standard benchmark pipeline
        once for an unbiased test-set evaluation.
+
+Grid is 2 x 3 x 3 = 18 trials.  Each trial performs a full fit() on
+Beijing Air, so the total cost is ~18x a single training run.
+
+Note on num_heads: in this wrapper tod/dow/spatial embedding dims are 0,
+so model_dim = input_embedding_dim (24) + adaptive_embedding_dim (80) =
+104.  num_heads must divide 104, which is why we search {2, 4, 8}
+(104 / 2 = 52, 104 / 4 = 26, 104 / 8 = 13).  Do not add values that
+aren't divisors of 104 without also adjusting the embedding dims.
 
 Usage:
     python examples/beijing_air_staeformer_example.py
@@ -25,9 +33,10 @@ base_config = STAEFormerConfig(
     early_stop=5,
 )
 
-# STAEFormer-specific search space (2x2 grid = 4 trials).
-# - lr         : training signal
-# - num_layers : transformer depth — the main capacity knob for STAEFormer
+# STAEFormer-specific search space (2 x 3 x 3 = 18 trials).
+# - lr         : training signal (log-scale pair)
+# - num_layers : transformer depth — the main capacity knob
+# - num_heads  : attention heads; all values must divide model_dim (104)
 tuner = HyperparameterTuner(
     model_factory=lambda: STAEFormerModel(),
     base_config=base_config,
@@ -35,7 +44,8 @@ tuner = HyperparameterTuner(
     workspace_dir=WORKSPACE,
     search_space={
         "lr":         Categorical([1e-3, 5e-4]),
-        "num_layers": Categorical([2, 3]),
+        "num_layers": Categorical([2, 3, 4]),
+        "num_heads":  Categorical([2, 4, 8]),
     },
     strategy="grid",
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ packages = [
     "gnn_benchmark.models",
     "gnn_benchmark.models.STAEFormer",
     "gnn_benchmark.models.STAEFormer.model",
+    "gnn_benchmark.tuning",
     "gnn_benchmark.utils",
 ]
 

--- a/tuning/__init__.py
+++ b/tuning/__init__.py
@@ -1,0 +1,36 @@
+"""Hyperparameter tuning for GNN Benchmark model submissions.
+
+Public entry points:
+
+- :class:`HyperparameterTuner` — grid / random search over a model's
+  config dataclass, driven entirely by validation loss.  The test set is
+  never touched during tuning.
+- :class:`TuningResult`, :class:`TrialResult` — result containers.
+- :class:`Categorical`, :class:`IntUniform`, :class:`Uniform`,
+  :class:`LogUniform` — search-space primitives, shaped to match Optuna's
+  ``trial.suggest_*`` API.
+"""
+
+from gnn_benchmark.tuning.search_space import (
+    Categorical,
+    IntUniform,
+    LogUniform,
+    Sampler,
+    Uniform,
+)
+from gnn_benchmark.tuning.tuner import (
+    HyperparameterTuner,
+    TrialResult,
+    TuningResult,
+)
+
+__all__ = [
+    "HyperparameterTuner",
+    "TuningResult",
+    "TrialResult",
+    "Sampler",
+    "Categorical",
+    "IntUniform",
+    "Uniform",
+    "LogUniform",
+]

--- a/tuning/search_space.py
+++ b/tuning/search_space.py
@@ -1,0 +1,136 @@
+"""Search-space primitives for the hyperparameter tuner.
+
+Each :class:`Sampler` represents one hyperparameter dimension.  The same
+object supports both grid search (via :meth:`grid_values`) and random
+search (via :meth:`sample`), and is shaped to map 1-to-1 onto
+Optuna's ``trial.suggest_*`` API so a future ``OptunaTuner`` can reuse
+the same search-space objects without call-site changes.
+
+Usage::
+
+    from gnn_benchmark.tuning import Categorical, LogUniform, IntUniform
+
+    search_space = {
+        "lr":      LogUniform(1e-4, 1e-2),
+        "dropout": Categorical([0.1, 0.3, 0.5]),
+        "nhid":    IntUniform(16, 64, step=16),
+    }
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Any, Protocol, Sequence, runtime_checkable
+
+
+@runtime_checkable
+class Sampler(Protocol):
+    """One hyperparameter dimension.
+
+    Implementations must provide :meth:`sample` (random search) and may
+    provide :meth:`grid_values` (grid search) — continuous samplers such as
+    :class:`Uniform` raise when asked for grid values.
+    """
+
+    def sample(self, rng: random.Random) -> Any: ...
+
+    def grid_values(self) -> list[Any]: ...
+
+
+@dataclass(frozen=True)
+class Categorical:
+    """Discrete choice over a fixed list of values.
+
+    Supports both grid and random search.
+    """
+
+    choices: Sequence[Any]
+
+    def __post_init__(self) -> None:
+        if len(self.choices) == 0:
+            raise ValueError("Categorical needs at least one choice.")
+
+    def sample(self, rng: random.Random) -> Any:
+        return rng.choice(list(self.choices))
+
+    def grid_values(self) -> list[Any]:
+        return list(self.choices)
+
+
+@dataclass(frozen=True)
+class IntUniform:
+    """Integer range ``[low, high]`` inclusive with optional step.
+
+    Supports both grid and random search.
+    """
+
+    low: int
+    high: int
+    step: int = 1
+
+    def __post_init__(self) -> None:
+        if self.step <= 0:
+            raise ValueError("step must be positive")
+        if self.high < self.low:
+            raise ValueError("high must be >= low")
+
+    def sample(self, rng: random.Random) -> int:
+        values = self.grid_values()
+        return rng.choice(values)
+
+    def grid_values(self) -> list[int]:
+        return list(range(self.low, self.high + 1, self.step))
+
+
+@dataclass(frozen=True)
+class Uniform:
+    """Continuous uniform range ``[low, high]``.
+
+    Random search only — :meth:`grid_values` raises.
+    """
+
+    low: float
+    high: float
+
+    def __post_init__(self) -> None:
+        if self.high < self.low:
+            raise ValueError("high must be >= low")
+
+    def sample(self, rng: random.Random) -> float:
+        return rng.uniform(self.low, self.high)
+
+    def grid_values(self) -> list[float]:
+        raise TypeError(
+            "Uniform is continuous and has no grid values; use IntUniform or "
+            "Categorical for grid search, or switch strategy='random'."
+        )
+
+
+@dataclass(frozen=True)
+class LogUniform:
+    """Log-uniform range ``[low, high]`` (both strictly positive).
+
+    Random search only.
+    """
+
+    low: float
+    high: float
+
+    def __post_init__(self) -> None:
+        if self.low <= 0 or self.high <= 0:
+            raise ValueError("LogUniform requires strictly positive bounds")
+        if self.high < self.low:
+            raise ValueError("high must be >= low")
+
+    def sample(self, rng: random.Random) -> float:
+        log_lo = math.log(self.low)
+        log_hi = math.log(self.high)
+        return math.exp(rng.uniform(log_lo, log_hi))
+
+    def grid_values(self) -> list[float]:
+        raise TypeError(
+            "LogUniform is continuous and has no grid values; use "
+            "Categorical for log-scale grid search."
+        )

--- a/tuning/tuner.py
+++ b/tuning/tuner.py
@@ -1,0 +1,355 @@
+"""Lightweight hyperparameter tuner for :class:`BenchmarkModel` submissions.
+
+The tuner is model-agnostic: its logic is identical for every model.  Each
+caller supplies the **search space** that matches its own config dataclass
+— GWN tunes ``nhid``, MTGNN tunes ``conv_channels``, and so on — so the
+set of hyperparameters varies per model, while the machinery does not.
+
+Design rules
+------------
+- Selection is driven **only** by validation loss (min of
+  :attr:`gnn_benchmark.models.TrainingHistory.val_loss`). The test set is
+  never seen during tuning; the tuner does not call ``predict()`` and
+  never touches ``x_test`` / ``y_test``.
+- Data preparation happens **once**, via
+  :meth:`gnn_benchmark.benchmark.BenchmarkRunner.prepare_dataset`. Each
+  trial only pays for a fresh ``model.fit(...)`` call.
+- The search-space API mirrors Optuna's ``trial.suggest_*`` shape, so a
+  future ``OptunaTuner`` subclass can be dropped in without changing any
+  existing call sites.
+
+Typical usage::
+
+    from gnn_benchmark.benchmark import BenchmarkRunner
+    from gnn_benchmark.models import GWNConfig, GWNModel
+    from gnn_benchmark.tuning import HyperparameterTuner, Categorical
+
+    base = GWNConfig(max_epochs=10, batch_size=32, early_stop=5)
+
+    tuner = HyperparameterTuner(
+        model_factory=lambda: GWNModel(),
+        base_config=base,
+        dataset_key="beijing-air",
+        workspace_dir="./benchmark_workspace",
+        search_space={
+            "lr":      Categorical([1e-3, 5e-4]),
+            "dropout": Categorical([0.1, 0.3]),
+        },
+        strategy="grid",
+    )
+    tuning_result = tuner.run()
+    print(tuning_result.summary())
+
+    # Final, unbiased evaluation — uses the winning config exactly once.
+    runner = BenchmarkRunner(
+        workspace_dir="./benchmark_workspace",
+        datasets=["beijing-air"],
+    )
+    final = runner.run(GWNModel(), config=tuning_result.best.config)
+    print(final.summary())
+"""
+
+from __future__ import annotations
+
+import itertools
+import random
+import time
+import traceback
+from dataclasses import asdict, dataclass, field, is_dataclass, replace
+from pathlib import Path
+from typing import Any, Callable, Mapping
+
+from gnn_benchmark.benchmark import BenchmarkRunner, PreparedDataset
+from gnn_benchmark.core.workspace import DataWorkspace
+from gnn_benchmark.models import BenchmarkModel, TrainingHistory
+from gnn_benchmark.tuning.search_space import Sampler
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TrialResult:
+    """Outcome of a single tuning trial.
+
+    ``config`` is the full config passed to ``fit`` (base + overrides).
+    ``overrides`` records only the fields the tuner varied, so results are
+    easy to read in the summary table.
+    """
+
+    trial_index: int
+    overrides: dict[str, Any]
+    config: Any
+    best_val_loss: float | None
+    train_history: TrainingHistory | None
+    duration_sec: float
+    error: str | None = None
+
+
+@dataclass
+class TuningResult:
+    """Aggregated output of :meth:`HyperparameterTuner.run`."""
+
+    model_name: str
+    dataset_name: str
+    trials: list[TrialResult] = field(default_factory=list)
+    best: TrialResult | None = None
+
+    def summary(self) -> str:
+        """Return a formatted table of trials and the winning config."""
+        lines: list[str] = []
+        thick = "═" * 72
+        thin = "─" * 72
+
+        lines.append(f"\nTuning — model={self.model_name}  dataset={self.dataset_name}")
+        lines.append(thick)
+        if not self.trials:
+            lines.append("(no trials run)")
+            lines.append(thick)
+            return "\n".join(lines)
+
+        # Header
+        field_names = sorted({k for t in self.trials for k in t.overrides})
+        header = f"{'trial':<6} {'val_loss':>10}  "
+        header += "  ".join(f"{n:>12}" for n in field_names)
+        lines.append(header)
+        lines.append(thin)
+
+        for t in self.trials:
+            if t.error is not None:
+                row = f"{t.trial_index:<6} {'ERROR':>10}  "
+            elif t.best_val_loss is None:
+                row = f"{t.trial_index:<6} {'—':>10}  "
+            else:
+                row = f"{t.trial_index:<6} {t.best_val_loss:>10.4f}  "
+            row += "  ".join(f"{str(t.overrides.get(n, '')):>12}" for n in field_names)
+            if self.best is not None and t.trial_index == self.best.trial_index:
+                row += "  ← best"
+            if t.error is not None:
+                row += f"  ERROR: {t.error}"
+            lines.append(row)
+
+        lines.append(thick)
+        if self.best is not None:
+            lines.append(f"Best: trial {self.best.trial_index}  "
+                         f"val_loss={self.best.best_val_loss:.4f}  "
+                         f"overrides={self.best.overrides}")
+        lines.append(thick)
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        """Return a JSON-serialisable representation."""
+        return {
+            "model_name": self.model_name,
+            "dataset_name": self.dataset_name,
+            "trials": [
+                {
+                    "trial_index": t.trial_index,
+                    "overrides": t.overrides,
+                    "config": asdict(t.config) if is_dataclass(t.config) else None,
+                    "best_val_loss": t.best_val_loss,
+                    "train_loss": t.train_history.train_loss if t.train_history else None,
+                    "val_loss": t.train_history.val_loss if t.train_history else None,
+                    "duration_sec": t.duration_sec,
+                    "error": t.error,
+                }
+                for t in self.trials
+            ],
+            "best_trial_index": self.best.trial_index if self.best else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tuner
+# ---------------------------------------------------------------------------
+
+class HyperparameterTuner:
+    """Grid / random search over a model's config dataclass.
+
+    Args:
+        model_factory:  Zero-arg callable returning a fresh
+                        :class:`BenchmarkModel` per trial.
+        base_config:    Config dataclass instance (e.g. ``GWNConfig(...)``).
+                        Each trial clones this via ``dataclasses.replace``
+                        and applies its overrides.
+        dataset_key:    Key into ``BenchmarkRunner.DATASET_REGISTRY``.  A
+                        single dataset per tuning run — keeps the control
+                        loop simple and the signal (val loss) comparable
+                        across trials.
+        workspace_dir:  Passed to ``DataWorkspace``.
+        search_space:   Mapping ``field_name -> Sampler``.  Field names must
+                        exist on ``base_config`` — validated up front so
+                        typos fail fast rather than silently ignoring a
+                        misnamed knob.
+        strategy:       ``"grid"`` (default) or ``"random"``.
+        n_trials:       Required for random search; ignored for grid search
+                        (which runs the full Cartesian product).
+        seed:           Seeds the random sampler for reproducibility.
+        verbose:        Print per-trial progress.
+    """
+
+    def __init__(
+        self,
+        model_factory: Callable[[], BenchmarkModel],
+        base_config: Any,
+        dataset_key: str,
+        workspace_dir: str | Path = "./benchmark_workspace",
+        search_space: Mapping[str, Sampler] | None = None,
+        strategy: str = "grid",
+        n_trials: int | None = None,
+        seed: int | None = None,
+        verbose: bool = True,
+    ) -> None:
+        if not is_dataclass(base_config):
+            raise TypeError(
+                "base_config must be a dataclass instance (e.g. GWNConfig)."
+            )
+        if strategy not in {"grid", "random"}:
+            raise ValueError(f"strategy must be 'grid' or 'random', got {strategy!r}")
+        if strategy == "random" and (n_trials is None or n_trials <= 0):
+            raise ValueError("strategy='random' requires n_trials > 0.")
+
+        search_space = dict(search_space or {})
+        if not search_space:
+            raise ValueError("search_space is empty — nothing to tune.")
+
+        # Fail fast on typos: every field must exist on the dataclass.
+        base_field_names = {f.name for f in base_config.__dataclass_fields__.values()}
+        unknown = set(search_space) - base_field_names
+        if unknown:
+            raise ValueError(
+                f"search_space references fields that are not on "
+                f"{type(base_config).__name__}: {sorted(unknown)}"
+            )
+
+        self.model_factory = model_factory
+        self.base_config = base_config
+        self.dataset_key = dataset_key
+        self.workspace_dir = Path(workspace_dir)
+        self.search_space = search_space
+        self.strategy = strategy
+        self.n_trials = n_trials
+        self.seed = seed
+        self.verbose = verbose
+
+    # ------------------------------------------------------------------
+
+    def _enumerate_trials(self) -> list[dict[str, Any]]:
+        """Produce the list of override dicts for every trial, in order."""
+        if self.strategy == "grid":
+            names = list(self.search_space)
+            value_lists = [self.search_space[n].grid_values() for n in names]
+            return [
+                dict(zip(names, combo))
+                for combo in itertools.product(*value_lists)
+            ]
+
+        # random
+        rng = random.Random(self.seed)
+        trials: list[dict[str, Any]] = []
+        for _ in range(self.n_trials or 0):
+            trials.append(
+                {name: sampler.sample(rng) for name, sampler in self.search_space.items()}
+            )
+        return trials
+
+    # ------------------------------------------------------------------
+
+    def run(self) -> TuningResult:
+        """Run all trials and return a :class:`TuningResult`.
+
+        The test set is **never** touched.  Each trial only invokes
+        ``model.fit(x_train, y_train, x_val, y_val, adj, config)`` and
+        reads ``min(TrainingHistory.val_loss)`` as the objective.
+        """
+        # Prepare data once — train/val/test splits are identical to what
+        # BenchmarkRunner would produce for a final evaluation run.
+        workspace = DataWorkspace(self.workspace_dir)
+        runner = BenchmarkRunner(
+            workspace_dir=self.workspace_dir,
+            datasets=[self.dataset_key],
+            verbose=self.verbose,
+        )
+        prepared: PreparedDataset = runner.prepare_dataset(workspace, self.dataset_key)
+
+        trial_overrides = self._enumerate_trials()
+        result = TuningResult(
+            model_name=self._model_name(),
+            dataset_name=self.dataset_key,
+        )
+
+        self._log(
+            f"\n[tuner] {self._model_name()} on {self.dataset_key}: "
+            f"{len(trial_overrides)} trial(s) via {self.strategy} search."
+        )
+
+        for idx, overrides in enumerate(trial_overrides):
+            trial_cfg = replace(self.base_config, **overrides)
+            self._log(f"[tuner] trial {idx + 1}/{len(trial_overrides)}  overrides={overrides}")
+
+            start = time.time()
+            history: TrainingHistory | None = None
+            best_val: float | None = None
+            error: str | None = None
+
+            try:
+                model = self.model_factory()
+                history = model.fit(
+                    prepared.x_train, prepared.y_train,
+                    prepared.x_val, prepared.y_val,
+                    prepared.adj, trial_cfg,
+                )
+                if history is None:
+                    raise RuntimeError(
+                        "model.fit() returned None — the tuner needs a "
+                        "TrainingHistory with per-epoch val_loss to score trials."
+                    )
+                if not history.val_loss:
+                    raise RuntimeError(
+                        "TrainingHistory.val_loss is empty; cannot score trial."
+                    )
+                best_val = float(min(history.val_loss))
+            except Exception as exc:  # noqa: BLE001
+                error = f"{type(exc).__name__}: {exc}"
+                if self.verbose:
+                    traceback.print_exc()
+
+            duration = time.time() - start
+            trial = TrialResult(
+                trial_index=idx,
+                overrides=overrides,
+                config=trial_cfg,
+                best_val_loss=best_val,
+                train_history=history,
+                duration_sec=duration,
+                error=error,
+            )
+            result.trials.append(trial)
+
+            if error is not None:
+                self._log(f"[tuner] trial {idx} FAILED — {error}")
+            else:
+                self._log(
+                    f"[tuner] trial {idx} done  "
+                    f"best_val_loss={best_val:.4f}  ({duration:.1f}s)"
+                )
+
+        # Pick winner: smallest finite val loss.
+        valid = [t for t in result.trials if t.best_val_loss is not None]
+        if valid:
+            result.best = min(valid, key=lambda t: t.best_val_loss)  # type: ignore[arg-type]
+
+        return result
+
+    # ------------------------------------------------------------------
+
+    def _model_name(self) -> str:
+        try:
+            return self.model_factory().name
+        except Exception:  # noqa: BLE001
+            return type(self.base_config).__name__.replace("Config", "")
+
+    def _log(self, msg: str) -> None:
+        if self.verbose:
+            print(msg)


### PR DESCRIPTION
## Summary

This PR introduces a lightweight, model-agnostic hyperparameter tuning framework that enables grid and random search over model config dataclasses. The tuner is driven entirely by validation loss and never touches the test set, ensuring unbiased final evaluation.

## Key Changes

- **New tuning module** (`tuning/tuner.py`, `tuning/search_space.py`, `tuning/__init__.py`):
  - `HyperparameterTuner`: Main class supporting grid and random search strategies
  - `TuningResult` / `TrialResult`: Result containers with formatted summary output and JSON serialization
  - Search-space primitives: `Categorical`, `IntUniform`, `Uniform`, `LogUniform` shaped to match Optuna's API for future extensibility

- **Refactored benchmark pipeline** (`benchmark.py`):
  - Extracted data preparation into `prepare_dataset()` method, returning a new `PreparedDataset` dataclass
  - This allows the tuner and benchmark runner to use identical train/val/test splits
  - `_run_dataset()` now calls `prepare_dataset()` internally, maintaining backward compatibility

- **Updated examples** (all four Beijing Air examples):
  - Converted from single fixed-config runs to tuning + final evaluation pipelines
  - Each example demonstrates model-specific search spaces (e.g., GWN tunes `lr`, `dropout`, `nhid`)
  - Added detailed comments explaining grid sizes and parameter choices

## Implementation Details

- **Design principles**:
  - Selection driven only by validation loss; test set never accessed during tuning
  - Data preparation happens once; each trial only pays for `model.fit()`
  - Search-space API mirrors Optuna's `trial.suggest_*` shape for future `OptunaTuner` subclass compatibility

- **Error handling**: Trials that fail are recorded with error messages; tuning continues and reports which trials succeeded

- **Reproducibility**: Random search supports optional seed parameter for deterministic trial generation

- **Validation**: Search-space field names are validated against the config dataclass up front to catch typos early

https://claude.ai/code/session_014m82NX9AeHUMjABZHAG3gp