### PR TITLE
Add NY COVID dataset with smoothing, lagging, and connectivity analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,10 @@ list_of_models.txt
 /models_prep/testingtxt.py
 /models_prep/testingpickle.py
 *__pycache__/*
+__pycache__/
 *.egg-info/
 .eggs/
+
+# Local workspace + example output artifacts
+/benchmark_workspace/
+/ny_covid_explore_out/

--- a/datasets/ny_covid.py
+++ b/datasets/ny_covid.py
@@ -22,8 +22,20 @@ FIPS_MAP_RAW_URL = (
     "https://raw.githubusercontent.com/josh-byster/fips_lat_long/master/fips_map.json"
 )
 
-_FEATURES = ["new_cases", "new_deaths"]
-_UNITS = {"new_cases": "cases/day", "new_deaths": "deaths/day"}
+# 7-day backward rolling window for smoothing daily noise (weekend/Monday
+# reporting cadence, single-day backfills).
+SMOOTH_WINDOW = 7
+# 14-day lag: cases at t-14 are aligned with deaths at t (epidemiological
+# lag between infection reporting and death).
+CASES_LAG_DAYS = 14
+
+# Target (deaths) is listed first so model wrappers that slice std[:D_out]
+# and assume the target is the first feature column work correctly.
+_FEATURES = ["new_deaths_smooth", "new_cases_smooth_lag14"]
+_UNITS = {
+    "new_deaths_smooth": "deaths/day (7-day mean)",
+    "new_cases_smooth_lag14": "cases/day (7-day mean, 14-day lag)",
+}
 
 
 @dataclass
@@ -33,8 +45,11 @@ class NYCovidLoader(DatasetLoader):
 
     Downloads cumulative case and death counts for US counties, geolocated via
     FIPS coordinates, and differences them into daily new cases / new deaths.
-    new_cases is the prediction target, so it is the leading feature column
-    (model wrappers slice std[:D_out] and assume the target is first).
+    Both series are then 7-day backward-smoothed and the cases series is
+    shifted forward by 14 days so that each row pairs deaths at day t with
+    cases from day t-14 (the epidemiological lag). new_deaths_smooth is the
+    prediction target, so it is the leading feature column (model wrappers
+    slice std[:D_out] and assume the target is first).
 
     Node order is determined at download time from the intersection of NYT
     county records and the FIPS coordinate map, stored as sorted FIPS strings,
@@ -53,12 +68,18 @@ class NYCovidLoader(DatasetLoader):
             node_order=list(self._node_order),
             feature_columns=_FEATURES,
             units=_UNITS,
-            window_config=WindowConfig(target_columns=["new_cases"]),
+            window_config=WindowConfig(target_columns=["new_deaths_smooth"]),
             description=(
                 "NYT COVID-19 US county-level daily new cases and deaths, "
                 "Jan 2020 – Mar 2023 (NYT stopped county-level updates on "
-                "2023-03-23). Target: new_cases. Edges: fully connected, "
-                "weighted by haversine distance."
+                "2023-03-23). Both series are smoothed with a 7-day backward "
+                "rolling mean; cases are shifted forward by 14 days so that "
+                "cases_smooth_lag14[t] = smoothed_cases[t-14], mirroring the "
+                "epidemiological lag between cases and deaths. The first 14 "
+                "days of deaths and the last 14 days of cases are cut so "
+                "every retained row has both aligned signals. Target: "
+                "new_deaths_smooth. Edges: fully connected, weighted by "
+                "haversine distance."
             ),
         )
 
@@ -151,14 +172,25 @@ class NYCovidLoader(DatasetLoader):
     def _build_series(
         self, merged: pd.DataFrame, all_fips: list[int]
     ) -> pd.DataFrame:
-        """Build densified series panel of daily new cases / new deaths.
+        """Build densified series panel of smoothed, lag-aligned cases/deaths.
 
         NYT reports cumulative counts per county. We reindex onto the full
         daily grid, forward-fill the cumulative within each FIPS (a missing
         report means the cumulative did not change), fill leading gaps with 0
         (pre-first-report days had no cases), then difference per FIPS to get
         daily new counts. Negative deltas from data revisions are clipped to
-        0, so the resulting series is non-negative and NaN-free.
+        0, so the raw daily series is non-negative and NaN-free.
+
+        The daily series is noisy (weekend under-reporting, Monday backfills,
+        single-day data dumps), so we apply a 7-day backward rolling mean per
+        county (min_periods=7 → the first 6 days per county are dropped).
+
+        To predict deaths from cases with a 2-week epidemiological lag, each
+        output row at date t carries the smoothed cases from t-14 alongside
+        the smoothed deaths at t. This drops the first 14 days (no lag source
+        for cases) and effectively drops the last 14 days of cases (they
+        would predict deaths beyond the dataset end). Combined with the
+        6-day smoothing warm-up, the first 20 days of the series are dropped.
         """
         all_dates = pd.date_range(merged["date"].min(), merged["date"].max(), freq="D")
 
@@ -181,18 +213,39 @@ class NYCovidLoader(DatasetLoader):
             .fillna(0.0)
             .clip(lower=0.0)
             .astype(float)
+            .rename(columns={"cases": "new_cases", "deaths": "new_deaths"})
         )
 
-        out = new.reset_index().rename(
-            columns={
-                "date": "ts",
-                "fips": "node_id",
-                "cases": "new_cases",
-                "deaths": "new_deaths",
-            }
+        # Re-shape to (date, fips) long form and sort within each county so
+        # rolling / shift operations respect time order.
+        daily = new.reset_index().rename(columns={"date": "ts", "fips": "node_id"})
+        daily["node_id"] = daily["node_id"].astype(str)
+        daily = daily.sort_values(["node_id", "ts"]).reset_index(drop=True)
+
+        # 7-day backward rolling mean per county. min_periods=7 leaves the
+        # first 6 days per county NaN (user: "ignore this for the first 6 days").
+        def _smooth(s: pd.Series) -> pd.Series:
+            return s.rolling(window=SMOOTH_WINDOW, min_periods=SMOOTH_WINDOW).mean()
+
+        grouped = daily.groupby("node_id", sort=False)
+        daily["new_deaths_smooth"] = grouped["new_deaths"].transform(_smooth)
+        # Shift smoothed cases forward by 14 days so row at date t holds the
+        # smoothed cases from t-14 (still grouped by county).
+        daily["new_cases_smooth_lag14"] = grouped["new_cases"].transform(
+            lambda s: _smooth(s).shift(CASES_LAG_DAYS)
         )
-        out["node_id"] = out["node_id"].astype(str)
-        out = out[["ts", "node_id", "new_cases", "new_deaths"]]
+
+        # Drop rows where either aligned signal is still NaN. In practice
+        # this removes the first 20 days per county (6-day smoothing warm-up
+        # + 14-day lag). The unused tail cases (last 14 days) are simply not
+        # present in the aligned panel.
+        aligned = daily.dropna(
+            subset=["new_deaths_smooth", "new_cases_smooth_lag14"]
+        ).copy()
+
+        out = aligned[
+            ["ts", "node_id", "new_deaths_smooth", "new_cases_smooth_lag14"]
+        ]
         return out.sort_values(["ts", "node_id"]).reset_index(drop=True)
 
     @staticmethod

--- a/datasets/ny_covid.py
+++ b/datasets/ny_covid.py
@@ -28,6 +28,15 @@ SMOOTH_WINDOW = 7
 # 14-day lag: cases at t-14 are aligned with deaths at t (epidemiological
 # lag between infection reporting and death).
 CASES_LAG_DAYS = 14
+# Distance cutoff for the county adjacency graph (haversine, metres).
+# 150 km was chosen from the isolated-node / connected-component sweep in
+# examples/ny_covid_explore.py: it keeps the fraction of isolated nodes
+# under ~0.5% (17/3212 counties — mostly offshore territories like Hawaii
+# and Puerto Rico) while cutting the edge count by roughly two orders of
+# magnitude relative to the fully connected graph. Counties beyond this
+# distance from every other county are emitted with no edges, which the
+# adjacency-matrix builder already handles as a zero row/column.
+EDGE_DISTANCE_CUTOFF_M = 150_000.0
 
 # Target (deaths) is listed first so model wrappers that slice std[:D_out]
 # and assume the target is the first feature column work correctly.
@@ -78,8 +87,9 @@ class NYCovidLoader(DatasetLoader):
                 "epidemiological lag between cases and deaths. The first 14 "
                 "days of deaths and the last 14 days of cases are cut so "
                 "every retained row has both aligned signals. Target: "
-                "new_deaths_smooth. Edges: fully connected, weighted by "
-                "haversine distance."
+                "new_deaths_smooth. Edges: haversine distance with a "
+                f"{EDGE_DISTANCE_CUTOFF_M / 1000:.0f} km cutoff (isolated "
+                "counties keep zero edges)."
             ),
         )
 
@@ -252,7 +262,14 @@ class NYCovidLoader(DatasetLoader):
     def _compute_edges(
         coords: pd.DataFrame, all_fips: list[int]
     ) -> pd.DataFrame:
-        """Compute symmetric haversine distance edges between all counties."""
+        """Compute symmetric haversine distance edges, keeping only pairs
+        within ``EDGE_DISTANCE_CUTOFF_M`` (inclusive).
+
+        Counties whose nearest neighbour is beyond the cutoff (e.g., Hawaii,
+        Puerto Rico) contribute no edges. The adjacency matrix builder
+        treats missing edges as zero, so isolated nodes simply have a zero
+        row/column.
+        """
         county_coords = (
             coords[coords["fips"].isin(all_fips)]
             .copy()
@@ -263,10 +280,11 @@ class NYCovidLoader(DatasetLoader):
         rows_list: list[tuple[str, str, float]] = []
         records = county_coords.to_dict("records")
         for a, b in combinations(records, 2):
+            dist_m = haversine_distance(a["lat"], a["lon"], b["lat"], b["lon"])
+            if dist_m > EDGE_DISTANCE_CUTOFF_M:
+                continue
+            dist = round(dist_m, 1)
             fa, fb = str(int(a["fips"])), str(int(b["fips"]))
-            dist = round(
-                haversine_distance(a["lat"], a["lon"], b["lat"], b["lon"]), 1
-            )
             rows_list.append((fa, fb, dist))
             rows_list.append((fb, fa, dist))
 

--- a/examples/lamah_ce_dynamic_d2stgnn_example.py
+++ b/examples/lamah_ce_dynamic_d2stgnn_example.py
@@ -17,9 +17,18 @@ Dataset:
 
 Note:
     D2STGNN *does* use the supplied river-network adjacency (via
-    doubletransition).  This combines well with its dynamic graph learning.
+    doubletransition). This combines well with its dynamic graph
+    learning.
 
-Grid is 2 x 3 x 3 = 18 trials.
+Memory notes:
+    Per layer D2STGNN holds (B, T, N, num_hidden) activations and a
+    dynamic-graph scores tensor of shape (B, N, N). With N=859 and
+    batch_size=32 the scores tensor alone is ~95 MB per layer; gradients
+    double that. Dropping ``batch_size`` to 16 and ``num_hidden`` to 16
+    cuts memory roughly 4× and resolves most OOMs on 12 GB cards. If
+    tight, further reduce ``batch_size`` to 8.
+
+Grid is 2 x 2 x 2 = 8 trials (down from 18) to keep the sweep bounded.
 
 Usage:
     python examples/lamah_ce_dynamic_d2stgnn_example.py
@@ -36,13 +45,15 @@ print(f"[example] D2STGNN on {DATASET} — workspace={WORKSPACE}")
 
 base_config = D2STGNNConfig(
     max_epochs=10,
-    batch_size=32,
+    batch_size=16,
     early_stop=5,
+    num_hidden=16,
 )
 
-# D2STGNN-specific search space (2 x 3 x 3 = 18 trials).
+# D2STGNN-specific search space (2 x 2 x 2 = 8 trials).
 # - lr         : D2STGNN's default (2e-3) is higher than GWN/MTGNN
-# - num_hidden : hidden channel width — the main capacity knob
+# - num_hidden : hidden channel width — the main capacity knob;
+#                (B,T,N,C) activation memory is linear in this.
 # - dropout    : regularisation; D2STGNN uses a lower default (0.1)
 tuner = HyperparameterTuner(
     model_factory=lambda: D2STGNNModel(),
@@ -51,12 +62,12 @@ tuner = HyperparameterTuner(
     workspace_dir=WORKSPACE,
     search_space={
         "lr":         Categorical([2e-3, 1e-3]),
-        "num_hidden": Categorical([16, 32, 64]),
-        "dropout":    Categorical([0.1, 0.2, 0.3]),
+        "num_hidden": Categorical([16, 32]),
+        "dropout":    Categorical([0.1, 0.2]),
     },
     strategy="grid",
 )
-print("[example] Starting hyperparameter grid search (18 trials)...")
+print("[example] Starting hyperparameter grid search (8 trials)...")
 tuning_result = tuner.run()
 print("[example] Tuning complete.")
 print(tuning_result.summary())

--- a/examples/lamah_ce_dynamic_staeformer_example.py
+++ b/examples/lamah_ce_dynamic_staeformer_example.py
@@ -15,14 +15,24 @@ Dataset:
     The loader auto-downloads the Zenodo archive on first use and caches
     it under ``~/.cache/gnn_benchmark/lamah_ce/``.
 
-Note on num_heads: in this wrapper tod/dow/spatial embedding dims are 0,
-so model_dim = input_embedding_dim (24) + adaptive_embedding_dim (80) =
-104.  num_heads must divide 104, which is why we search {2, 4, 8}.
+Memory notes:
+    Spatial self-attention scales with N² per head per layer. With
+    N=859 gauges, model_dim=104, num_heads=4 and the default 3 layers
+    this comes out to ~47M fp32 entries per batch of 16 just for the
+    attention scores — tight on 12 GB cards and a common OOM source.
+    We halve ``adaptive_embedding_dim`` (80 → 40, model_dim drops to
+    64) and drop ``num_layers`` to 2 to cut attention memory ~4×.
+    If you still OOM, lower ``batch_size`` to 4 or set
+    ``adaptive_embedding_dim=16``.
+
+    With model_dim=64 the valid ``num_heads`` divisors are {2, 4, 8};
+    the search grid below stays inside that set.
 
 STAEFormer does not use the supplied graph — the transformer + adaptive
 embedding ignore `adj`.
 
-Grid is 2 x 3 x 3 = 18 trials.
+Grid is 2 x 2 x 2 = 8 trials (down from 18) to keep the sweep bounded
+while the per-trial memory footprint is smaller.
 
 Usage:
     python examples/lamah_ce_dynamic_staeformer_example.py
@@ -39,14 +49,19 @@ print(f"[example] STAEFormer on {DATASET} — workspace={WORKSPACE}")
 
 base_config = STAEFormerConfig(
     max_epochs=10,
-    batch_size=16,
+    batch_size=8,
     early_stop=5,
+    adaptive_embedding_dim=40,
+    feed_forward_dim=128,
+    num_layers=2,
 )
 
-# STAEFormer-specific search space (2 x 3 x 3 = 18 trials).
+# STAEFormer-specific search space (2 x 2 x 2 = 8 trials).
 # - lr         : training signal (log-scale pair)
-# - num_layers : transformer depth — the main capacity knob
-# - num_heads  : attention heads; all values must divide model_dim (104)
+# - num_layers : transformer depth; kept low because each layer doubles
+#                the spatial-attention activation footprint.
+# - num_heads  : attention heads; all values must divide model_dim (64
+#                with the config above).
 tuner = HyperparameterTuner(
     model_factory=lambda: STAEFormerModel(),
     base_config=base_config,
@@ -54,12 +69,12 @@ tuner = HyperparameterTuner(
     workspace_dir=WORKSPACE,
     search_space={
         "lr":         Categorical([1e-3, 5e-4]),
-        "num_layers": Categorical([2, 3, 4]),
-        "num_heads":  Categorical([2, 4, 8]),
+        "num_layers": Categorical([1, 2]),
+        "num_heads":  Categorical([2, 4]),
     },
     strategy="grid",
 )
-print("[example] Starting hyperparameter grid search (18 trials)...")
+print("[example] Starting hyperparameter grid search (8 trials)...")
 tuning_result = tuner.run()
 print("[example] Tuning complete.")
 print(tuning_result.summary())

--- a/examples/ny_covid_d2stgnn_example.py
+++ b/examples/ny_covid_d2stgnn_example.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Tune D2STGNN on NY COVID (county-level), then report test metrics.
+
+Pipeline:
+    1. Run a grid search over D2STGNN-specific hyperparameters, scored
+       by validation loss. The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline
+       once for an unbiased test-set evaluation.
+
+Dataset:
+    NYT COVID-19 county-level, 7-day-smoothed deaths aligned with the
+    14-day-lagged smoothed cases. Target: ``new_deaths_smooth``.
+    N = 3,212 counties, T = 1,138 days, D_in = 2.
+    Graph: haversine distances with a 150 km cutoff (~128k directed
+    edges). D2STGNN DOES use the supplied adjacency (via
+    doubletransition) and combines it with learned dynamic graph
+    structure.
+
+Memory notes:
+    D2STGNN's decoupling block stacks a diffusion conv + dynamic-graph
+    conv per layer, with activations of shape (B, T, N, num_hidden).
+    The dynamic-graph branch additionally computes an N×N scores
+    tensor per layer (3,212² = ~40 MB at fp32), and gradients double
+    that. Knobs applied below:
+      - batch_size=8             : 4× smaller than LamaH-CE example;
+                                   (B, T, N, C) scales linearly with B.
+      - num_hidden=16            : halved from 32; residual and conv
+                                   stacks all use this width.
+      - num_modalities=2         : kept at default — cheaper than adding
+                                   hidden width for the same capacity.
+
+Usage:
+    python examples/ny_covid_d2stgnn_example.py
+"""
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
+
+WORKSPACE = "./benchmark_workspace"
+DATASET = "nyc-covid"
+
+print(f"[example] D2STGNN on {DATASET} — workspace={WORKSPACE}")
+
+base_config = D2STGNNConfig(
+    max_epochs=10,
+    batch_size=8,
+    early_stop=5,
+    num_hidden=16,
+)
+
+tuner = HyperparameterTuner(
+    model_factory=lambda: D2STGNNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":         Categorical([2e-3, 1e-3]),
+        "num_hidden": Categorical([16, 32]),
+        "dropout":    Categorical([0.1, 0.2]),
+    },
+    strategy="grid",
+)
+print("[example] Starting hyperparameter grid search (8 trials)...")
+tuning_result = tuner.run()
+print("[example] Tuning complete.")
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    print("[example] Running final evaluation on test set with best config...")
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(D2STGNNModel(), config=tuning_result.best.config)
+    print("[example] Final evaluation complete.")
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/ny_covid_explore.py
+++ b/examples/ny_covid_explore.py
@@ -364,6 +364,9 @@ def main() -> None:
     print("Running connectivity analysis on distance graph...")
     conn = connectivity_analysis(ir.edges, nodes)
     plot_connectivity_curve(conn, OUT_DIR / "09_connectivity_vs_cutoff.png")
+    plot_isolation_curve(
+        conn["first_neighbor_dist"], OUT_DIR / "10_isolated_nodes_vs_cutoff.png"
+    )
 
     # ── Per-feature stats summary ────────────────────────────────────────────
     n_all_zero_cases = int((cases_stats["total"] == 0).sum())
@@ -429,6 +432,10 @@ def main() -> None:
         "-" * 60,
         format_connectivity_report(conn),
         "",
+        "Isolated-node count at sub-d_min cutoffs",
+        "-" * 60,
+        format_isolation_report(conn["first_neighbor_dist"]),
+        "",
         "Diagnostics — major issues flagged for training",
         "=" * 60,
         diagnostics,
@@ -485,6 +492,9 @@ def connectivity_analysis(
       - events:            list[(distance, components_after)], sorted by
                            ascending distance, one entry per component merge
       - n_events:          int, number of merges (always n_nodes - 1)
+      - first_neighbor_dist: np.ndarray of length n_nodes, distance to each
+                           node's nearest neighbour (so # isolated at cutoff
+                           c is just (first_neighbor_dist > c).sum()).
     """
     if edges is None or edges.empty or len(nodes) <= 1:
         return {
@@ -493,6 +503,7 @@ def connectivity_analysis(
             "d_full_connected": float("nan"),
             "events": [],
             "n_events": 0,
+            "first_neighbor_dist": np.array([], dtype=np.float64),
         }
 
     node_to_idx = {n: i for i, n in enumerate(nodes)}
@@ -548,7 +559,143 @@ def connectivity_analysis(
         "d_full_connected": d_full_connected,
         "events": events,
         "n_events": len(events),
+        "first_neighbor_dist": first_neighbor_dist,
     }
+
+
+# Cutoffs (in metres) at which the isolation count is tabulated. Chosen
+# as a geometric sweep across the sub-d_min_degree range to expose where
+# the number of isolated nodes starts "exploding" — i.e. the elbow of the
+# isolation-vs-cutoff curve. The largest value is just above the
+# observed d_min_degree (~1263 km) so the sweep brackets the full range.
+ISOLATION_CUTOFFS_KM = (
+    25, 50, 75, 100, 150, 200, 300, 400, 500, 600, 800, 1000, 1200, 1300,
+)
+
+
+def plot_isolation_curve(
+    first_neighbor_dist: np.ndarray, out_path: Path
+) -> None:
+    """Plot # isolated nodes vs distance cutoff.
+
+    A node is "isolated" at cutoff c iff its nearest-neighbour distance
+    exceeds c. The curve is the complementary CDF of first-neighbour
+    distances, shown on linear and log-log axes side by side so the
+    explosion point (the elbow where isolation count grows rapidly as the
+    cutoff drops) is visible on either scale.
+    """
+    if first_neighbor_dist.size == 0:
+        return
+
+    # Use every sorted first-neighbour distance as a curve point — at a
+    # cutoff equal to the k-th smallest first-neighbour distance, exactly
+    # N - k nodes are isolated (the ones with larger nearest-neighbour
+    # distance). Prepend 0 so the curve starts at N (cutoff=0 → every
+    # node isolated). Drop any infinite values defensively.
+    finite = first_neighbor_dist[np.isfinite(first_neighbor_dist)]
+    sorted_fnd = np.sort(finite)
+    N = first_neighbor_dist.size
+    # At cutoff = sorted_fnd[k] (inclusive), nodes with fnd > cutoff are
+    # isolated; that is N - (k + 1) nodes (because sorted_fnd[k] is
+    # included).
+    cutoffs_m = np.concatenate([[0.0], sorted_fnd])
+    isolated = np.concatenate([[N], N - np.arange(1, sorted_fnd.size + 1)])
+
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+    # Linear axes
+    axes[0].plot(cutoffs_m / 1000.0, isolated, color="C0", linewidth=1.2)
+    axes[0].set_xlabel("Distance cutoff (km)")
+    axes[0].set_ylabel("# isolated nodes")
+    axes[0].set_title("Isolated nodes vs cutoff (linear)")
+    axes[0].grid(alpha=0.3)
+
+    # Log-log axes — compress the "almost everyone isolated" range so the
+    # elbow is easy to see.
+    axes[1].plot(cutoffs_m / 1000.0, isolated, color="C0", linewidth=1.2)
+    axes[1].set_xscale("log")
+    axes[1].set_yscale("log")
+    axes[1].set_xlabel("Distance cutoff (km, log)")
+    axes[1].set_ylabel("# isolated nodes (log)")
+    axes[1].set_title("Isolated nodes vs cutoff (log-log)")
+    axes[1].grid(alpha=0.3, which="both")
+
+    # Mark the discrete tabulated cutoffs on both axes.
+    for km in ISOLATION_CUTOFFS_KM:
+        n_iso = int((first_neighbor_dist > km * 1000.0).sum())
+        for ax in axes:
+            ax.axvline(km, color="C7", alpha=0.25, linewidth=0.6)
+        axes[0].annotate(
+            f"{km}km\n{n_iso}",
+            xy=(km, n_iso),
+            xytext=(2, 2),
+            textcoords="offset points",
+            fontsize=7,
+            color="C3",
+        )
+
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def format_isolation_report(first_neighbor_dist: np.ndarray) -> str:
+    """Table of # isolated nodes at a geometric sweep of cutoffs,
+    plus an 'explosion' hint computed from the steepest log-log drop."""
+    if first_neighbor_dist.size == 0:
+        return "  (no edges — isolation sweep skipped)"
+
+    rows = [
+        "  cutoff (km) |  # isolated  |  % isolated  |  Δ since prev",
+        "  " + "-" * 56,
+    ]
+    N = first_neighbor_dist.size
+    prev = None
+    for km in ISOLATION_CUTOFFS_KM:
+        n_iso = int((first_neighbor_dist > km * 1000.0).sum())
+        pct = 100.0 * n_iso / N
+        delta = "" if prev is None else f"  {prev - n_iso:+d}"
+        rows.append(
+            f"  {km:>10d} |  {n_iso:>10d}  |  {pct:>9.2f}%  |{delta}"
+        )
+        prev = n_iso
+
+    # Heuristic elbow: the cutoff where the biggest *relative* jump in
+    # isolation happens as the cutoff decreases. Using finite differences
+    # on the tabulated grid so the signal comes from the requested
+    # cutoffs rather than the dense per-node curve.
+    iso_by_cutoff = [
+        int((first_neighbor_dist > km * 1000.0).sum())
+        for km in ISOLATION_CUTOFFS_KM
+    ]
+    # Δlog(iso) between adjacent grid points, computed as we walk the
+    # cutoff downward (so positive Δlog = isolation count grew when
+    # cutoff shrank, i.e. the "explosion" direction).
+    best_ratio = 0.0
+    best_pair = None
+    for (km_hi, iso_hi), (km_lo, iso_lo) in zip(
+        list(zip(ISOLATION_CUTOFFS_KM, iso_by_cutoff))[1:],
+        list(zip(ISOLATION_CUTOFFS_KM, iso_by_cutoff))[:-1],
+    ):
+        if iso_hi <= 0:
+            continue
+        ratio = iso_lo / max(iso_hi, 1)
+        if ratio > best_ratio:
+            best_ratio = ratio
+            best_pair = (km_lo, iso_lo, km_hi, iso_hi)
+
+    hint = ""
+    if best_pair is not None:
+        km_lo, iso_lo, km_hi, iso_hi = best_pair
+        hint = (
+            f"\n  Steepest relative growth between tabulated cutoffs: "
+            f"{km_hi}→{km_lo} km, isolated {iso_hi}→{iso_lo} "
+            f"(x{best_ratio:.2f}). Below this the isolation count starts "
+            "dominating; treat this as the first hint of where to NOT "
+            "set the cutoff."
+        )
+
+    return "\n".join(rows) + hint
 
 
 def plot_connectivity_curve(conn: dict, out_path: Path) -> None:

--- a/examples/ny_covid_explore.py
+++ b/examples/ny_covid_explore.py
@@ -1,21 +1,28 @@
 #!/usr/bin/env python3
 """Exploratory analysis of the NY COVID-19 county-level dataset.
 
-This script does NOT train a model. It loads the prepared NY_Covid IR and
-generates a set of figures + a printed summary aimed at the questions you
-need to answer before modelling:
+This script does NOT train a model. It loads the prepared NY_Covid IR
+(already 7-day smoothed and 14-day lag-aligned: each row pairs deaths at
+day t with cases from day t-14) and generates a set of figures + a
+printed summary aimed at the questions you need to answer before
+modelling:
 
     - When does the dataset actually start / end per county?
     - How many counties are reporting on any given day?
-    - How long are the runs of zero new_cases / zero new_deaths per
-      county? (long zero stretches are the main worry.)
+    - How long are the runs of zero cases / deaths per county?
+      (long zero stretches are the main worry for small counties.)
     - What fraction of days are zeros per county?
     - How skewed is the per-county total? (a few huge counties dominate.)
-    - Is there a day-of-week reporting cadence (Monday dumps, weekend
-      under-reporting)?
-    - Are there single-day spikes that look like data dumps rather than
-      real epidemiology?
+    - Day-of-week pattern — should be flat after 7-day smoothing.
+    - Residual single-day spikes after smoothing.
     - A few representative county time series for a sanity check.
+    - Graph connectivity as a function of distance cutoff — what's the
+      smallest cutoff that leaves no isolated nodes, what's the smallest
+      cutoff that makes the graph fully connected, and every cutoff
+      between those two at which the number of connected components
+      drops by one.
+    - A diagnostics section flagging major issues that would make
+      training models on this dataset problematic.
 
 Outputs go to ``./ny_covid_explore_out/`` as PNGs plus a text summary.
 
@@ -40,11 +47,18 @@ WORKSPACE_DIR = Path("./benchmark_workspace")
 OUT_DIR = Path("./ny_covid_explore_out")
 NYC_FIPS = "99999"
 
-# Top-K counties (by total new_cases) plotted individually
+# Column names in the aligned IR. Cases are already shifted back 14 days
+# at the loader level, so CASES_COL[t] = smoothed raw cases at day t-14.
+CASES_COL = "new_cases_smooth_lag14"
+DEATHS_COL = "new_deaths_smooth"
+
+# Top-K counties (by total cases) plotted individually
 TOP_K_SAMPLE = 3
-# Bottom-K counties (by total new_cases, excluding all-zero) plotted individually
+# Bottom-K counties (by total cases, excluding all-zero) plotted individually
 BOT_K_SAMPLE = 3
-# Spike threshold: a day's value exceeding (median * MULT) of that county
+# Spike threshold: a day's value exceeding (median * MULT) of that county.
+# After 7-day smoothing real spikes > 50x median are essentially impossible,
+# so any such spike is a diagnostic red flag rather than normal behaviour.
 SPIKE_MULT = 50.0
 
 
@@ -103,15 +117,15 @@ def per_county_stats(
 
 def plot_aggregate_daily(daily: pd.DataFrame, out_path: Path) -> None:
     fig, axes = plt.subplots(2, 1, figsize=(12, 6), sharex=True)
-    axes[0].plot(daily.index, daily["new_cases"], color="C0", linewidth=0.9)
-    axes[0].set_ylabel("Total new cases / day")
-    axes[0].set_title("Aggregate daily new cases (sum across all counties)")
+    axes[0].plot(daily.index, daily[CASES_COL], color="C0", linewidth=0.9)
+    axes[0].set_ylabel("Total smoothed cases / day (14-day lag)")
+    axes[0].set_title("Aggregate smoothed cases (sum across all counties)")
     axes[0].grid(alpha=0.3)
 
-    axes[1].plot(daily.index, daily["new_deaths"], color="C3", linewidth=0.9)
-    axes[1].set_ylabel("Total new deaths / day")
+    axes[1].plot(daily.index, daily[DEATHS_COL], color="C3", linewidth=0.9)
+    axes[1].set_ylabel("Total smoothed deaths / day")
     axes[1].set_xlabel("Date")
-    axes[1].set_title("Aggregate daily new deaths (sum across all counties)")
+    axes[1].set_title("Aggregate smoothed deaths (sum across all counties)")
     axes[1].grid(alpha=0.3)
     fig.tight_layout()
     fig.savefig(out_path, dpi=120)
@@ -119,15 +133,15 @@ def plot_aggregate_daily(daily: pd.DataFrame, out_path: Path) -> None:
 
 
 def plot_reporting_coverage(panel: pd.DataFrame, out_path: Path) -> None:
-    """Number of counties with non-zero new_cases per day."""
+    """Number of counties with non-zero smoothed cases per day."""
     coverage = (
-        panel.assign(reporting=(panel["new_cases"] > 0).astype(int))
+        panel.assign(reporting=(panel[CASES_COL] > 0).astype(int))
         .groupby("ts")["reporting"]
         .sum()
     )
     fig, ax = plt.subplots(figsize=(12, 4))
     ax.plot(coverage.index, coverage.values, color="C2", linewidth=0.9)
-    ax.set_ylabel("# counties with new_cases > 0")
+    ax.set_ylabel(f"# counties with {CASES_COL} > 0")
     ax.set_xlabel("Date")
     ax.set_title("Reporting coverage over time")
     ax.grid(alpha=0.3)
@@ -141,13 +155,13 @@ def plot_zero_fraction_hist(
 ) -> None:
     fig, axes = plt.subplots(1, 2, figsize=(12, 4))
     axes[0].hist(cases_stats["zero_frac"], bins=40, color="C0", edgecolor="black")
-    axes[0].set_title("Per-county fraction of days with new_cases = 0")
+    axes[0].set_title(f"Per-county fraction of days with {CASES_COL} = 0")
     axes[0].set_xlabel("Zero-day fraction")
     axes[0].set_ylabel("# counties")
     axes[0].grid(alpha=0.3)
 
     axes[1].hist(deaths_stats["zero_frac"], bins=40, color="C3", edgecolor="black")
-    axes[1].set_title("Per-county fraction of days with new_deaths = 0")
+    axes[1].set_title(f"Per-county fraction of days with {DEATHS_COL} = 0")
     axes[1].set_xlabel("Zero-day fraction")
     axes[1].grid(alpha=0.3)
     fig.tight_layout()
@@ -162,7 +176,7 @@ def plot_longest_zero_streak_hist(
     axes[0].hist(
         cases_stats["longest_zero_run"], bins=40, color="C0", edgecolor="black"
     )
-    axes[0].set_title("Longest contiguous run of new_cases = 0 per county")
+    axes[0].set_title(f"Longest contiguous run of {CASES_COL} = 0 per county")
     axes[0].set_xlabel("Days")
     axes[0].set_ylabel("# counties")
     axes[0].grid(alpha=0.3)
@@ -170,7 +184,7 @@ def plot_longest_zero_streak_hist(
     axes[1].hist(
         deaths_stats["longest_zero_run"], bins=40, color="C3", edgecolor="black"
     )
-    axes[1].set_title("Longest contiguous run of new_deaths = 0 per county")
+    axes[1].set_title(f"Longest contiguous run of {DEATHS_COL} = 0 per county")
     axes[1].set_xlabel("Days")
     axes[1].grid(alpha=0.3)
     fig.tight_layout()
@@ -182,14 +196,13 @@ def plot_total_per_county_hist(
     cases_stats: pd.DataFrame, deaths_stats: pd.DataFrame, out_path: Path
 ) -> None:
     fig, axes = plt.subplots(1, 2, figsize=(12, 4))
-    # log1p so a zero-total county still maps to bin 0
     axes[0].hist(
         np.log10(cases_stats["total"].clip(lower=1.0)),
         bins=40,
         color="C0",
         edgecolor="black",
     )
-    axes[0].set_title("Per-county total new_cases (log10)")
+    axes[0].set_title(f"Per-county total {CASES_COL} (log10)")
     axes[0].set_xlabel("log10(total cases)")
     axes[0].set_ylabel("# counties")
     axes[0].grid(alpha=0.3)
@@ -200,7 +213,7 @@ def plot_total_per_county_hist(
         color="C3",
         edgecolor="black",
     )
-    axes[1].set_title("Per-county total new_deaths (log10)")
+    axes[1].set_title(f"Per-county total {DEATHS_COL} (log10)")
     axes[1].set_xlabel("log10(total deaths)")
     axes[1].grid(alpha=0.3)
     fig.tight_layout()
@@ -212,7 +225,7 @@ def plot_dow_pattern(panel: pd.DataFrame, out_path: Path) -> None:
     dow = panel["ts"].dt.day_name()
     by_dow = (
         panel.assign(dow=dow)
-        .groupby("dow")[["new_cases", "new_deaths"]]
+        .groupby("dow")[[CASES_COL, DEATHS_COL]]
         .mean()
         .reindex(
             [
@@ -227,14 +240,14 @@ def plot_dow_pattern(panel: pd.DataFrame, out_path: Path) -> None:
         )
     )
     fig, axes = plt.subplots(1, 2, figsize=(12, 4))
-    axes[0].bar(by_dow.index, by_dow["new_cases"], color="C0", edgecolor="black")
-    axes[0].set_title("Mean new_cases per (county, day) by weekday")
+    axes[0].bar(by_dow.index, by_dow[CASES_COL], color="C0", edgecolor="black")
+    axes[0].set_title(f"Mean {CASES_COL} per (county, day) by weekday")
     axes[0].set_ylabel("Mean")
     axes[0].tick_params(axis="x", rotation=30)
     axes[0].grid(alpha=0.3, axis="y")
 
-    axes[1].bar(by_dow.index, by_dow["new_deaths"], color="C3", edgecolor="black")
-    axes[1].set_title("Mean new_deaths per (county, day) by weekday")
+    axes[1].bar(by_dow.index, by_dow[DEATHS_COL], color="C3", edgecolor="black")
+    axes[1].set_title(f"Mean {DEATHS_COL} per (county, day) by weekday")
     axes[1].tick_params(axis="x", rotation=30)
     axes[1].grid(alpha=0.3, axis="y")
     fig.tight_layout()
@@ -252,13 +265,13 @@ def plot_sample_counties(
         axes = [axes]
     for ax, nid in zip(axes, sample_ids):
         sub = panel[panel["node_id"] == nid].sort_values("ts")
-        ax.plot(sub["ts"], sub["new_cases"], color="C0", linewidth=0.7, label="cases")
-        ax.plot(sub["ts"], sub["new_deaths"], color="C3", linewidth=0.7, label="deaths")
+        ax.plot(sub["ts"], sub[CASES_COL], color="C0", linewidth=0.7, label="cases (t-14)")
+        ax.plot(sub["ts"], sub[DEATHS_COL], color="C3", linewidth=0.7, label="deaths")
         ax.set_ylabel(f"FIPS {nid}")
         ax.grid(alpha=0.3)
         ax.legend(loc="upper right", fontsize=8)
     axes[-1].set_xlabel("Date")
-    fig.suptitle("Sample county time series")
+    fig.suptitle("Sample county time series (smoothed, cases lagged 14d)")
     fig.tight_layout()
     fig.savefig(out_path, dpi=120)
     plt.close(fig)
@@ -270,7 +283,7 @@ def plot_spike_distribution(
     """For each county compute max/median ratio (excl. zero medians)."""
     ratios: list[float] = []
     for _, sub in panel.groupby("node_id", sort=False):
-        v = sub["new_cases"].to_numpy()
+        v = sub[CASES_COL].to_numpy()
         nz = v[v > 0]
         if nz.size < 10:
             continue
@@ -281,7 +294,7 @@ def plot_spike_distribution(
     fig, ax = plt.subplots(figsize=(8, 4))
     if ratios:
         ax.hist(np.log10(ratios), bins=40, color="C4", edgecolor="black")
-    ax.set_title("Per-county max(new_cases) / median(non-zero new_cases) (log10)")
+    ax.set_title(f"Per-county max({CASES_COL}) / median(non-zero) (log10)")
     ax.set_xlabel("log10(spike ratio)")
     ax.set_ylabel("# counties")
     ax.grid(alpha=0.3)
@@ -311,12 +324,12 @@ def main() -> None:
     n_edges = 0 if ir.edges is None else len(ir.edges)
 
     # ── Aggregate daily series ────────────────────────────────────────────────
-    daily = panel.groupby("ts")[["new_cases", "new_deaths"]].sum().sort_index()
+    daily = panel.groupby("ts")[[CASES_COL, DEATHS_COL]].sum().sort_index()
 
     # ── Per-county stats ──────────────────────────────────────────────────────
     print("Computing per-county statistics...")
-    cases_stats = per_county_stats(panel, "new_cases")
-    deaths_stats = per_county_stats(panel, "new_deaths")
+    cases_stats = per_county_stats(panel, CASES_COL)
+    deaths_stats = per_county_stats(panel, DEATHS_COL)
 
     # Pick sample counties: top-K, bottom-K (>0), and NYC if present
     by_total = cases_stats["total"].sort_values()
@@ -347,7 +360,12 @@ def main() -> None:
     plot_sample_counties(panel, sample_ids, OUT_DIR / "07_sample_counties.png")
     plot_spike_distribution(panel, OUT_DIR / "08_spike_distribution.png")
 
-    # ── Text summary ──────────────────────────────────────────────────────────
+    # ── Connectivity analysis ────────────────────────────────────────────────
+    print("Running connectivity analysis on distance graph...")
+    conn = connectivity_analysis(ir.edges, nodes)
+    plot_connectivity_curve(conn, OUT_DIR / "09_connectivity_vs_cutoff.png")
+
+    # ── Per-feature stats summary ────────────────────────────────────────────
     n_all_zero_cases = int((cases_stats["total"] == 0).sum())
     n_all_zero_deaths = int((deaths_stats["total"] == 0).sum())
     p99_zero_cases = float(cases_stats["longest_zero_run"].quantile(0.99))
@@ -356,30 +374,45 @@ def main() -> None:
     worst_cases_zeros = cases_stats["longest_zero_run"].sort_values(ascending=False).head(10)
     worst_deaths_zeros = deaths_stats["longest_zero_run"].sort_values(ascending=False).head(10)
 
+    # ── Diagnostics: major issues that would bite during training ────────────
+    spike_counties = detect_spike_counties(panel, SPIKE_MULT)
+    dense_edge_ratio = n_edges / max(N * (N - 1), 1)
+    diagnostics = run_diagnostics(
+        T=T,
+        N=N,
+        n_edges=n_edges,
+        dense_edge_ratio=dense_edge_ratio,
+        cases_stats=cases_stats,
+        deaths_stats=deaths_stats,
+        spike_counties=spike_counties,
+        panel=panel,
+    )
+
+    # ── Text summary ──────────────────────────────────────────────────────────
     lines = [
         "NY_Covid exploratory summary",
         "=" * 60,
         f"Days (T):              {T}",
         f"Counties (N):          {N}",
-        f"Edges:                 {n_edges}",
+        f"Edges (directed):      {n_edges}",
         f"Date range:            {panel['ts'].min().date()} → {panel['ts'].max().date()}",
-        f"Total new_cases:       {int(daily['new_cases'].sum()):,}",
-        f"Total new_deaths:      {int(daily['new_deaths'].sum()):,}",
+        f"Total {CASES_COL}: {daily[CASES_COL].sum():,.0f}",
+        f"Total {DEATHS_COL}: {daily[DEATHS_COL].sum():,.0f}",
         "",
         f"Synthetic NYC FIPS ({NYC_FIPS}) present in node_order: "
         f"{NYC_FIPS in nodes}",
         "",
-        "Zero-day fractions (cases):",
+        f"Zero-day fractions ({CASES_COL}):",
         f"  median {cases_stats['zero_frac'].median():.2f}  "
         f"mean {cases_stats['zero_frac'].mean():.2f}  "
         f"p95 {cases_stats['zero_frac'].quantile(0.95):.2f}",
-        "Zero-day fractions (deaths):",
+        f"Zero-day fractions ({DEATHS_COL}):",
         f"  median {deaths_stats['zero_frac'].median():.2f}  "
         f"mean {deaths_stats['zero_frac'].mean():.2f}  "
         f"p95 {deaths_stats['zero_frac'].quantile(0.95):.2f}",
         "",
-        f"Counties with ALL-ZERO new_cases:  {n_all_zero_cases}",
-        f"Counties with ALL-ZERO new_deaths: {n_all_zero_deaths}",
+        f"Counties with ALL-ZERO {CASES_COL}:  {n_all_zero_cases}",
+        f"Counties with ALL-ZERO {DEATHS_COL}: {n_all_zero_deaths}",
         "",
         f"Longest zero-cases streak (p99):   {p99_zero_cases:.0f} days",
         f"Longest zero-deaths streak (p99):  {p99_zero_deaths:.0f} days",
@@ -391,6 +424,14 @@ def main() -> None:
         worst_deaths_zeros.to_string(),
         "",
         f"Sample counties plotted (FIPS): {sample_ids}",
+        "",
+        "Connectivity vs distance cutoff (haversine, meters)",
+        "-" * 60,
+        format_connectivity_report(conn),
+        "",
+        "Diagnostics — major issues flagged for training",
+        "=" * 60,
+        diagnostics,
     ]
 
     summary = "\n".join(lines)
@@ -398,6 +439,383 @@ def main() -> None:
     print(summary)
     (OUT_DIR / "summary.txt").write_text(summary + "\n")
     print(f"\nSummary also written to {(OUT_DIR / 'summary.txt').resolve()}")
+
+
+# ── Connectivity analysis ─────────────────────────────────────────────────────
+
+
+class _UnionFind:
+    """Tiny union-find for Kruskal-style connectivity sweeps."""
+
+    def __init__(self, n: int) -> None:
+        self.parent = np.arange(n, dtype=np.int64)
+        self.rank = np.zeros(n, dtype=np.int8)
+
+    def find(self, a: int) -> int:
+        while self.parent[a] != a:
+            self.parent[a] = self.parent[self.parent[a]]
+            a = int(self.parent[a])
+        return a
+
+    def union(self, a: int, b: int) -> bool:
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return False
+        if self.rank[ra] < self.rank[rb]:
+            ra, rb = rb, ra
+        self.parent[rb] = ra
+        if self.rank[ra] == self.rank[rb]:
+            self.rank[ra] += 1
+        return True
+
+
+def connectivity_analysis(
+    edges: pd.DataFrame | None, nodes: list[str]
+) -> dict:
+    """
+    Sweep edges in ascending distance order and record, at every distance
+    that reduces the number of connected components, the (distance,
+    remaining components) pair. Also record the smallest cutoff such that
+    every node has at least one neighbour (i.e., no isolated nodes).
+
+    Returns a dict with:
+      - n_nodes:           int
+      - d_min_degree:      float, smallest cutoff with no isolated node
+      - d_full_connected:  float, smallest cutoff that makes graph connected
+      - events:            list[(distance, components_after)], sorted by
+                           ascending distance, one entry per component merge
+      - n_events:          int, number of merges (always n_nodes - 1)
+    """
+    if edges is None or edges.empty or len(nodes) <= 1:
+        return {
+            "n_nodes": len(nodes),
+            "d_min_degree": float("nan"),
+            "d_full_connected": float("nan"),
+            "events": [],
+            "n_events": 0,
+        }
+
+    node_to_idx = {n: i for i, n in enumerate(nodes)}
+    N = len(nodes)
+
+    # Keep only one direction of each undirected edge (src < dst lexically)
+    # to halve the work. Source edges are symmetric haversine distances.
+    und = edges[edges["src"].astype(str) < edges["dst"].astype(str)].copy()
+    # Sort edges by ascending cost once (stable) → kruskal-like sweep.
+    und = und.sort_values("cost", kind="mergesort").reset_index(drop=True)
+
+    src_idx = und["src"].astype(str).map(node_to_idx).to_numpy()
+    dst_idx = und["dst"].astype(str).map(node_to_idx).to_numpy()
+    cost = und["cost"].to_numpy()
+
+    uf = _UnionFind(N)
+    components = N
+    events: list[tuple[float, int]] = []
+
+    # Track the distance at which each node first acquires a neighbour.
+    # Since edges are sorted ascending, the first edge incident to a node
+    # gives that node's nearest-neighbour distance.
+    first_neighbor_dist = np.full(N, np.inf, dtype=np.float64)
+
+    for i in range(len(und)):
+        s = int(src_idx[i])
+        d = int(dst_idx[i])
+        c = float(cost[i])
+        if first_neighbor_dist[s] == np.inf:
+            first_neighbor_dist[s] = c
+        if first_neighbor_dist[d] == np.inf:
+            first_neighbor_dist[d] = c
+        if uf.union(s, d):
+            components -= 1
+            events.append((c, components))
+            if components == 1:
+                break
+
+    # d_min_degree: smallest cutoff so every node has >= 1 neighbour.
+    # This equals the max over nodes of their nearest-neighbour distance.
+    # If any node has no neighbour at all (shouldn't happen with a fully
+    # connected edge list, but defensively), this is +inf.
+    if np.isinf(first_neighbor_dist).any():
+        d_min_degree = float("inf")
+    else:
+        d_min_degree = float(first_neighbor_dist.max())
+
+    d_full_connected = events[-1][0] if events else float("nan")
+
+    return {
+        "n_nodes": N,
+        "d_min_degree": d_min_degree,
+        "d_full_connected": d_full_connected,
+        "events": events,
+        "n_events": len(events),
+    }
+
+
+def plot_connectivity_curve(conn: dict, out_path: Path) -> None:
+    """Plot number of connected components vs distance cutoff."""
+    events = conn["events"]
+    if not events:
+        return
+    # Build a staircase: before the first event components = N; after event
+    # i components = events[i][1]. We plot with a step function.
+    dists = np.array([e[0] for e in events])
+    comps = np.array([e[1] for e in events])
+    # Prepend start (0 distance, N components) so the curve begins at N.
+    dists = np.concatenate([[0.0], dists])
+    comps = np.concatenate([[conn["n_nodes"]], comps])
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    # Convert to km for readability
+    ax.step(dists / 1000.0, comps, where="post", color="C2", linewidth=1.2)
+    ax.set_xlabel("Distance cutoff (km)")
+    ax.set_ylabel("# connected components")
+    ax.set_yscale("log")
+    ax.set_title(
+        "Connected components vs distance cutoff (haversine, inclusive cutoff)"
+    )
+    ax.grid(alpha=0.3, which="both")
+
+    d1_km = conn["d_min_degree"] / 1000.0
+    d_full_km = conn["d_full_connected"] / 1000.0
+    ax.axvline(
+        d1_km, color="C1", linestyle="--", linewidth=1.0,
+        label=f"no isolated nodes (d={d1_km:.1f} km)",
+    )
+    ax.axvline(
+        d_full_km, color="C3", linestyle="--", linewidth=1.0,
+        label=f"fully connected (d={d_full_km:.1f} km)",
+    )
+    ax.legend(loc="upper right", fontsize=9)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)
+
+
+def format_connectivity_report(conn: dict) -> str:
+    """Short textual summary of the connectivity sweep, with every merge
+    event between d_min_degree and d_full_connected listed inline."""
+    if not conn["events"]:
+        return "  (no edges — connectivity analysis skipped)"
+
+    d1 = conn["d_min_degree"]
+    d_full = conn["d_full_connected"]
+    events = conn["events"]
+
+    # Filter the in-between events: distance strictly > d1 and <= d_full.
+    # (d1 itself is always a merge event since it is where the last
+    # singleton stops being isolated.)
+    between = [(d, c) for (d, c) in events if d1 < d <= d_full]
+
+    header = [
+        f"  nodes:                              {conn['n_nodes']}",
+        f"  lowest cutoff, no isolated nodes:   {d1:,.1f} m "
+        f"({d1 / 1000:,.2f} km)",
+        f"  lowest cutoff, fully connected:     {d_full:,.1f} m "
+        f"({d_full / 1000:,.2f} km)",
+        f"  merge events total:                 {len(events)}",
+        f"  merge events strictly after d_min:  {len(between)}",
+        "",
+        "  Every merge event (distance_m, components_after):",
+    ]
+
+    # To avoid dumping thousands of events to stdout when N is huge, sample
+    # if needed; but we still want the user to be able to pick a cutoff, so
+    # print all merges from d1 onwards (the user specifically asked for
+    # them) and downsample the pre-d1 history.
+    pre_d1 = [(d, c) for (d, c) in events if d < d1]
+    # Take at most 20 evenly-spaced pre-d1 samples so the printout stays
+    # readable without hiding the tail information the user actually asked
+    # for.
+    if len(pre_d1) > 20:
+        step = max(1, len(pre_d1) // 20)
+        pre_d1_shown = pre_d1[::step]
+        header.append(
+            f"    (pre-d_min events downsampled: {len(pre_d1)} total, "
+            f"showing every {step}th)"
+        )
+    else:
+        pre_d1_shown = pre_d1
+
+    rows: list[str] = []
+    for d, c in pre_d1_shown:
+        rows.append(f"    {d:>14,.1f} m   → {c} components")
+    rows.append(
+        f"    {d1:>14,.1f} m   → "
+        f"{next(c for (dd, c) in events if dd == d1)} components  "
+        f"[no isolated nodes]"
+    )
+    for d, c in between:
+        tag = "  [fully connected]" if d == d_full else ""
+        rows.append(f"    {d:>14,.1f} m   → {c} components{tag}")
+
+    return "\n".join(header + rows)
+
+
+# ── Diagnostics ───────────────────────────────────────────────────────────────
+
+
+def detect_spike_counties(panel: pd.DataFrame, mult: float) -> list[str]:
+    """Return FIPS of counties whose max cases > mult * median(non-zero)."""
+    offenders: list[str] = []
+    for nid, sub in panel.groupby("node_id", sort=False):
+        v = sub[CASES_COL].to_numpy()
+        nz = v[v > 0]
+        if nz.size < 10:
+            continue
+        med = float(np.median(nz))
+        if med > 0 and float(v.max()) > mult * med:
+            offenders.append(str(nid))
+    return offenders
+
+
+def run_diagnostics(
+    *,
+    T: int,
+    N: int,
+    n_edges: int,
+    dense_edge_ratio: float,
+    cases_stats: pd.DataFrame,
+    deaths_stats: pd.DataFrame,
+    spike_counties: list[str],
+    panel: pd.DataFrame,
+) -> str:
+    """Flag conditions that would make training GNN models problematic.
+
+    Each line is prefixed with '[!]' for an issue or '[ok]' for a
+    sanity-check pass. Thresholds are chosen to be conservative — when in
+    doubt the check fires so the user sees the issue.
+    """
+    findings: list[str] = []
+
+    # 1. Graph scale — an N×N dense adjacency costs 4·N² bytes (fp32) and
+    # most message-passing layers scale with |E|. With ~3k counties this
+    # gives ~9M directed edges, ~36 MB adjacency, quadratic memory during
+    # fitting. This is the motivation for the cutoff analysis above.
+    if N > 1000:
+        findings.append(
+            f"[!] N={N} counties with a fully connected graph → "
+            f"{n_edges:,} directed edges. Many GNN backbones will OOM or "
+            "run very slowly. Apply a distance cutoff before training."
+        )
+    else:
+        findings.append(f"[ok] N={N} counties; graph scale is manageable.")
+
+    if dense_edge_ratio > 0.9:
+        findings.append(
+            f"[!] Edge density {dense_edge_ratio:.2%} — graph is ~complete; "
+            "without a cutoff, neighbour-mean features are just global "
+            "means and the graph carries almost no inductive bias."
+        )
+
+    # 2. NYC synthetic FIPS — worth surfacing because the '99999' code and
+    # the Manhattan coordinate are both arbitrary and affect edge
+    # distances involving the five boroughs collapsed into a single node.
+    if NYC_FIPS in cases_stats.index:
+        findings.append(
+            f"[!] NYC (FIPS {NYC_FIPS}) is a synthetic node collapsing "
+            "the 5 boroughs into one county, geolocated at Manhattan. "
+            "Its population and distances are not borough-weighted."
+        )
+
+    # 3. All-zero counties — after smoothing, a county that never reported
+    # anything has constant 0 as input AND target, which inflates metrics
+    # (trivially perfect prediction) and contributes nothing during
+    # training. Worth either dropping or keeping as a sanity-check row.
+    n_all_zero_cases = int((cases_stats["total"] == 0).sum())
+    n_all_zero_deaths = int((deaths_stats["total"] == 0).sum())
+    if n_all_zero_cases > 0 or n_all_zero_deaths > 0:
+        findings.append(
+            f"[!] {n_all_zero_cases} counties have all-zero cases and "
+            f"{n_all_zero_deaths} have all-zero deaths across the entire "
+            "aligned series. They degenerate into trivially-correct "
+            "predictions; consider filtering them out."
+        )
+    else:
+        findings.append("[ok] No all-zero counties in cases or deaths.")
+
+    # 4. Long zero streaks — even after smoothing, small rural counties
+    # can have hundreds of consecutive zero days. Not wrong per se, but
+    # models trained with MAE/MSE will be biased toward zero and the
+    # effective training signal is concentrated in high-count counties.
+    p99_zero_cases = float(cases_stats["longest_zero_run"].quantile(0.99))
+    p99_zero_deaths = float(deaths_stats["longest_zero_run"].quantile(0.99))
+    if p99_zero_cases > 60:
+        findings.append(
+            f"[!] 99th-percentile longest zero-cases run is "
+            f"{p99_zero_cases:.0f} days; small counties dominate the "
+            "low-signal regime and may drag aggregate loss toward 0."
+        )
+    if p99_zero_deaths > 180:
+        findings.append(
+            f"[!] 99th-percentile longest zero-deaths run is "
+            f"{p99_zero_deaths:.0f} days; many counties have deaths "
+            "concentrated in short bursts separated by long zero gaps."
+        )
+
+    # 5. Residual single-day spikes even after 7-day smoothing — these
+    # usually indicate data dumps (multi-month backfills). They wreck
+    # normalisation statistics and training stability.
+    if spike_counties:
+        preview = ", ".join(spike_counties[:5])
+        extra = "" if len(spike_counties) <= 5 else f" (+{len(spike_counties) - 5} more)"
+        findings.append(
+            f"[!] {len(spike_counties)} counties still have a daily spike > "
+            f"{SPIKE_MULT:g}× their non-zero median after 7-day smoothing. "
+            f"Probable data-dump days. FIPS (sample): {preview}{extra}"
+        )
+    else:
+        findings.append(
+            f"[ok] No residual spikes > {SPIKE_MULT:g}× median after smoothing."
+        )
+
+    # 6. Heavy-tailed per-county totals — a few counties dominate. This
+    # forces per-node normalisation (or log-transform), otherwise the
+    # loss is driven by NYC / LA / Cook County while the rest of the
+    # graph is essentially noise.
+    totals = cases_stats["total"]
+    if totals.sum() > 0:
+        top10_share = totals.sort_values(ascending=False).head(10).sum() / totals.sum()
+        if top10_share > 0.25:
+            findings.append(
+                f"[!] Top-10 counties account for {top10_share:.1%} of total "
+                "cases — strong heavy-tail. Use per-node normalisation "
+                "or log1p, not a global z-score."
+            )
+
+    # 7. Day-of-week residue. After a 7-day moving average, weekday means
+    # should be essentially equal. If they are not, the smoothing did not
+    # fully absorb reporting cadence (e.g. because of ragged county
+    # start dates interacting with the window).
+    dow = panel["ts"].dt.day_name()
+    by_dow = panel.assign(dow=dow).groupby("dow")[CASES_COL].mean()
+    if by_dow.max() > 0:
+        dow_spread = (by_dow.max() - by_dow.min()) / by_dow.max()
+        if dow_spread > 0.10:
+            findings.append(
+                f"[!] Day-of-week spread in smoothed cases is "
+                f"{dow_spread:.1%} — smoothing did not fully absorb the "
+                "reporting cadence."
+            )
+        else:
+            findings.append(
+                f"[ok] Day-of-week spread in smoothed cases is "
+                f"{dow_spread:.1%} (smoothing absorbed the cadence)."
+            )
+
+    # 8. Coverage of aligned series. With 7-day smoothing + 14-day lag, the
+    # aligned series starts 20 days after the first observation; verify.
+    if T < 100:
+        findings.append(
+            f"[!] Aligned series has only {T} days — very short for "
+            "temporal forecasting with long input/horizon windows."
+        )
+    else:
+        findings.append(
+            f"[ok] Aligned series length T={T} days is long enough for "
+            "sliding-window forecasting."
+        )
+
+    return "\n".join(findings)
 
 
 if __name__ == "__main__":

--- a/examples/ny_covid_explore.py
+++ b/examples/ny_covid_explore.py
@@ -380,11 +380,13 @@ def main() -> None:
     # ── Diagnostics: major issues that would bite during training ────────────
     spike_counties = detect_spike_counties(panel, SPIKE_MULT)
     dense_edge_ratio = n_edges / max(N * (N - 1), 1)
+    n_isolated_nodes = int(np.isinf(conn["first_neighbor_dist"]).sum())
     diagnostics = run_diagnostics(
         T=T,
         N=N,
         n_edges=n_edges,
         dense_edge_ratio=dense_edge_ratio,
+        n_isolated_nodes=n_isolated_nodes,
         cases_stats=cases_stats,
         deaths_stats=deaths_stats,
         spike_counties=spike_counties,
@@ -551,7 +553,14 @@ def connectivity_analysis(
     else:
         d_min_degree = float(first_neighbor_dist.max())
 
-    d_full_connected = events[-1][0] if events else float("nan")
+    # d_full_connected only exists if components actually reached 1.
+    # If the sweep ended with the graph still disconnected (e.g. a
+    # distance cutoff was applied upstream so no edge joins Hawaii to
+    # the mainland), report +inf.
+    if components == 1 and events:
+        d_full_connected = events[-1][0]
+    else:
+        d_full_connected = float("inf")
 
     return {
         "n_nodes": N,
@@ -722,16 +731,28 @@ def plot_connectivity_curve(conn: dict, out_path: Path) -> None:
     )
     ax.grid(alpha=0.3, which="both")
 
-    d1_km = conn["d_min_degree"] / 1000.0
-    d_full_km = conn["d_full_connected"] / 1000.0
-    ax.axvline(
-        d1_km, color="C1", linestyle="--", linewidth=1.0,
-        label=f"no isolated nodes (d={d1_km:.1f} km)",
-    )
-    ax.axvline(
-        d_full_km, color="C3", linestyle="--", linewidth=1.0,
-        label=f"fully connected (d={d_full_km:.1f} km)",
-    )
+    d1 = conn["d_min_degree"]
+    d_full = conn["d_full_connected"]
+    if np.isfinite(d1):
+        ax.axvline(
+            d1 / 1000.0, color="C1", linestyle="--", linewidth=1.0,
+            label=f"no isolated nodes (d={d1 / 1000:.1f} km)",
+        )
+    if np.isfinite(d_full):
+        ax.axvline(
+            d_full / 1000.0, color="C3", linestyle="--", linewidth=1.0,
+            label=f"fully connected (d={d_full / 1000:.1f} km)",
+        )
+    # If the cutoff graph is disconnected, annotate the residual state
+    # so the reader knows why the curve doesn't reach 1.
+    components_final = conn["n_nodes"] - len(events)
+    n_iso = int(np.isinf(conn["first_neighbor_dist"]).sum())
+    if components_final > 1 or n_iso > 0:
+        ax.axhline(
+            components_final, color="C7", linestyle=":", linewidth=0.8,
+            label=f"residual components = {components_final} "
+            f"(incl. {n_iso} isolated nodes)",
+        )
     ax.legend(loc="upper right", fontsize=9)
     fig.tight_layout()
     fig.savefig(out_path, dpi=120)
@@ -739,40 +760,79 @@ def plot_connectivity_curve(conn: dict, out_path: Path) -> None:
 
 
 def format_connectivity_report(conn: dict) -> str:
-    """Short textual summary of the connectivity sweep, with every merge
-    event between d_min_degree and d_full_connected listed inline."""
-    if not conn["events"]:
+    """Short textual summary of the connectivity sweep.
+
+    Handles three cases:
+      1. The edge list covers every pair (pre-cutoff). We report
+         d_min_degree, d_full_connected, and every merge event from d_min
+         onwards.
+      2. A cutoff is in effect but the graph is still fully connected —
+         same as (1) but events only go up to the largest edge kept.
+      3. A cutoff leaves the graph disconnected (e.g. Hawaii, Puerto
+         Rico have no edges within 150 km). Then d_min_degree and/or
+         d_full_connected are +inf; we report the residual number of
+         isolated nodes and connected components instead.
+    """
+    if not conn["events"] and conn["first_neighbor_dist"].size == 0:
         return "  (no edges — connectivity analysis skipped)"
 
     d1 = conn["d_min_degree"]
     d_full = conn["d_full_connected"]
     events = conn["events"]
+    fnd = conn["first_neighbor_dist"]
 
-    # Filter the in-between events: distance strictly > d1 and <= d_full.
-    # (d1 itself is always a merge event since it is where the last
-    # singleton stops being isolated.)
-    between = [(d, c) for (d, c) in events if d1 < d <= d_full]
+    n_isolated_overall = int(np.isinf(fnd).sum())
+    # Components remaining after all known merges. Starts at N, drops by
+    # one per merge event.
+    components_final = conn["n_nodes"] - len(events)
+
+    def _fmt_m(x: float) -> str:
+        if not np.isfinite(x):
+            return "∞ (graph has permanent isolated nodes / components)"
+        return f"{x:,.1f} m ({x / 1000:,.2f} km)"
 
     header = [
         f"  nodes:                              {conn['n_nodes']}",
-        f"  lowest cutoff, no isolated nodes:   {d1:,.1f} m "
-        f"({d1 / 1000:,.2f} km)",
-        f"  lowest cutoff, fully connected:     {d_full:,.1f} m "
-        f"({d_full / 1000:,.2f} km)",
+        f"  lowest cutoff, no isolated nodes:   {_fmt_m(d1)}",
+        f"  lowest cutoff, fully connected:     {_fmt_m(d_full)}",
+        f"  isolated nodes (no edge at all):    {n_isolated_overall}",
+        f"  connected components remaining:     {components_final}",
         f"  merge events total:                 {len(events)}",
-        f"  merge events strictly after d_min:  {len(between)}",
-        "",
-        "  Every merge event (distance_m, components_after):",
     ]
 
-    # To avoid dumping thousands of events to stdout when N is huge, sample
-    # if needed; but we still want the user to be able to pick a cutoff, so
-    # print all merges from d1 onwards (the user specifically asked for
-    # them) and downsample the pre-d1 history.
+    # If d1 is +inf we cannot list events strictly between d1 and
+    # d_full; fall back to a downsampled event list covering the whole
+    # sweep so the caller still gets a feel for component structure.
+    if not np.isfinite(d1):
+        header.append(
+            "  (d_min_degree is infinite — the graph has permanent "
+            "isolated nodes with this edge set, so no cutoff in this "
+            "edge list can eliminate them)"
+        )
+        header.append("")
+        header.append(
+            "  Merge events, downsampled (distance_m, components_after):"
+        )
+        if len(events) > 40:
+            step = max(1, len(events) // 40)
+            sampled = events[::step]
+        else:
+            sampled = events
+        rows = [f"    {d:>14,.1f} m   → {c} components" for d, c in sampled]
+        return "\n".join(header + rows)
+
+    # Regular case: d_min_degree is finite. In-between events sit strictly
+    # between d1 and d_full; d1 itself is always a merge (it is where the
+    # last singleton stops being isolated).
+    if np.isfinite(d_full):
+        between = [(d, c) for (d, c) in events if d1 < d <= d_full]
+    else:
+        between = [(d, c) for (d, c) in events if d > d1]
+
+    header.append(f"  merge events strictly after d_min:  {len(between)}")
+    header += ["", "  Every merge event (distance_m, components_after):"]
+
     pre_d1 = [(d, c) for (d, c) in events if d < d1]
-    # Take at most 20 evenly-spaced pre-d1 samples so the printout stays
-    # readable without hiding the tail information the user actually asked
-    # for.
     if len(pre_d1) > 20:
         step = max(1, len(pre_d1) // 20)
         pre_d1_shown = pre_d1[::step]
@@ -786,13 +846,14 @@ def format_connectivity_report(conn: dict) -> str:
     rows: list[str] = []
     for d, c in pre_d1_shown:
         rows.append(f"    {d:>14,.1f} m   → {c} components")
-    rows.append(
-        f"    {d1:>14,.1f} m   → "
-        f"{next(c for (dd, c) in events if dd == d1)} components  "
-        f"[no isolated nodes]"
-    )
+    d1_event = next((c for (dd, c) in events if dd == d1), None)
+    if d1_event is not None:
+        rows.append(
+            f"    {d1:>14,.1f} m   → {d1_event} components  "
+            f"[no isolated nodes]"
+        )
     for d, c in between:
-        tag = "  [fully connected]" if d == d_full else ""
+        tag = "  [fully connected]" if np.isfinite(d_full) and d == d_full else ""
         rows.append(f"    {d:>14,.1f} m   → {c} components{tag}")
 
     return "\n".join(header + rows)
@@ -821,6 +882,7 @@ def run_diagnostics(
     N: int,
     n_edges: int,
     dense_edge_ratio: float,
+    n_isolated_nodes: int,
     cases_stats: pd.DataFrame,
     deaths_stats: pd.DataFrame,
     spike_counties: list[str],
@@ -834,24 +896,33 @@ def run_diagnostics(
     """
     findings: list[str] = []
 
-    # 1. Graph scale — an N×N dense adjacency costs 4·N² bytes (fp32) and
-    # most message-passing layers scale with |E|. With ~3k counties this
-    # gives ~9M directed edges, ~36 MB adjacency, quadratic memory during
-    # fitting. This is the motivation for the cutoff analysis above.
-    if N > 1000:
+    # 1. Graph scale — most message-passing layers scale with |E|. Report
+    # the actual edge count and average undirected degree; flag densities
+    # above 0.9 (~complete graph) and flag scale problems only if the
+    # graph is dense enough that training will blow up.
+    avg_undir_deg = (n_edges / 2.0) / max(N, 1)
+    if dense_edge_ratio > 0.9:
         findings.append(
-            f"[!] N={N} counties with a fully connected graph → "
-            f"{n_edges:,} directed edges. Many GNN backbones will OOM or "
-            "run very slowly. Apply a distance cutoff before training."
+            f"[!] N={N} counties with ~complete graph "
+            f"(density {dense_edge_ratio:.2%}, {n_edges:,} directed edges). "
+            "Neighbour-mean features are just global means; apply a "
+            "distance cutoff before training."
+        )
+    elif N > 1000:
+        findings.append(
+            f"[ok] N={N} counties, {n_edges:,} directed edges "
+            f"(avg undirected degree {avg_undir_deg:.1f}, density "
+            f"{dense_edge_ratio:.2%}). Graph scale is manageable."
         )
     else:
         findings.append(f"[ok] N={N} counties; graph scale is manageable.")
 
-    if dense_edge_ratio > 0.9:
+    if n_isolated_nodes > 0:
         findings.append(
-            f"[!] Edge density {dense_edge_ratio:.2%} — graph is ~complete; "
-            "without a cutoff, neighbour-mean features are just global "
-            "means and the graph carries almost no inductive bias."
+            f"[!] {n_isolated_nodes} counties have no edges at the current "
+            "distance cutoff (e.g. Hawaii, Puerto Rico). Their adjacency "
+            "row/column is zero, so GNN layers cannot use spatial signal "
+            "for them — they train as pure per-node temporal models."
         )
 
     # 2. NYC synthetic FIPS — worth surfacing because the '99999' code and

--- a/examples/ny_covid_gwn_example.py
+++ b/examples/ny_covid_gwn_example.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Tune Graph WaveNet on NY COVID (county-level), then report test metrics.
+
+Pipeline:
+    1. Run a grid search over GWN-specific hyperparameters, scored by
+       validation loss. The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline
+       once for an unbiased test-set evaluation.
+
+Dataset:
+    NYT COVID-19 county-level, 7-day-smoothed deaths aligned with the
+    14-day-lagged smoothed cases. Target: ``new_deaths_smooth``.
+    N = 3,212 counties (~4× LamaH-CE), T = 1,138 days, D_in = 2.
+    Graph: haversine distances with a 150 km cutoff (~128k directed
+    edges, avg degree ~20, 17 offshore counties isolated).
+
+Memory notes (see 'OOM mitigations' at the bottom):
+    With 3,212 nodes the per-batch activation tensors are roughly four
+    times larger than for LamaH-CE. GWN stacks 4 residual blocks × 2
+    layers of dilated conv by default; each intermediate tensor is
+    (B, nhid*8, N, T) at the skip connection. The config below halves
+    the hidden width and uses a small batch to fit comfortably on
+    12 GB cards; scale ``nhid`` and ``batch_size`` up once you confirm
+    headroom.
+
+Usage:
+    python examples/ny_covid_gwn_example.py
+"""
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import GWNConfig, GWNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
+
+WORKSPACE = "./benchmark_workspace"
+DATASET = "nyc-covid"
+
+print(f"[example] GWN on {DATASET} — workspace={WORKSPACE}")
+
+# Base config is intentionally lean for this dataset. Starting points
+# for the knobs that dominate memory:
+#   - batch_size=8   : 4× smaller than the LamaH-CE GWN example because
+#                      N is ~4× bigger; activation memory is ~linear in B·N.
+#   - nhid=16        : half the GWN default; skip/end channels derive
+#                      from nhid so this halves the widest tensors.
+#   - blocks=2       : default is 4; each block doubles the dilation
+#                      footprint.
+# Raise these back up once you confirm headroom on your GPU.
+base_config = GWNConfig(
+    max_epochs=10,
+    batch_size=8,
+    early_stop=5,
+    nhid=16,
+    blocks=2,
+)
+
+# Smaller 2×2×2 = 8-trial grid (vs 18 for LamaH-CE) so the whole sweep
+# stays within a reasonable wall-clock budget on a single GPU.
+tuner = HyperparameterTuner(
+    model_factory=lambda: GWNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":      Categorical([1e-3, 5e-4]),
+        "dropout": Categorical([0.1, 0.3]),
+        "nhid":    Categorical([16, 32]),
+    },
+    strategy="grid",
+)
+print("[example] Starting hyperparameter grid search (8 trials)...")
+tuning_result = tuner.run()
+print("[example] Tuning complete.")
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    print("[example] Running final evaluation on test set with best config...")
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(GWNModel(), config=tuning_result.best.config)
+    print("[example] Final evaluation complete.")
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/ny_covid_mtgnn_example.py
+++ b/examples/ny_covid_mtgnn_example.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Tune MTGNN on NY COVID (county-level), then report test metrics.
+
+Pipeline:
+    1. Run a grid search over MTGNN-specific hyperparameters, scored by
+       validation loss. The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline
+       once for an unbiased test-set evaluation.
+
+Dataset:
+    NYT COVID-19 county-level, 7-day-smoothed deaths aligned with the
+    14-day-lagged smoothed cases. Target: ``new_deaths_smooth``.
+    N = 3,212 counties, T = 1,138 days, D_in = 2.
+    Graph: haversine distances with a 150 km cutoff (~128k directed
+    edges, avg degree ~20, 17 offshore counties isolated).
+
+Note:
+    MTGNN ignores the supplied adjacency (``predefined_A=None`` in
+    ``models/mtgnn.py``) and learns its own graph via its graph
+    constructor. For N=3,212 the learned node embedding and subgraph
+    selection are the main memory terms; we reduce ``node_dim`` and
+    ``subgraph_size`` below to keep this in check.
+
+Memory notes:
+    MTGNN allocates an N×subgraph_size adjacency at every forward pass
+    plus (B, conv_channels, N, T) activations per layer. With N=3,212,
+    subgraph_size=10 costs ~32k float32 pairs per batch, which is fine;
+    the real memory cost is the (B, C, N, T) activations, so the knobs
+    that matter are ``batch_size`` and ``conv_channels``.
+
+Usage:
+    python examples/ny_covid_mtgnn_example.py
+"""
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import MTGNNConfig, MTGNNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
+
+WORKSPACE = "./benchmark_workspace"
+DATASET = "nyc-covid"
+
+print(f"[example] MTGNN on {DATASET} — workspace={WORKSPACE}")
+
+# MTGNN-specific memory notes:
+#   - batch_size=8        : 4× smaller than LamaH-CE example; (B,C,N,T)
+#                           activations scale linearly with B.
+#   - conv_channels=16    : halved from default; residual_channels is
+#                           tied, so this halves the widest tensors.
+#   - subgraph_size=10    : paper default is 20; with 3k nodes the
+#                           top-k neighbour mixer still has plenty of
+#                           variety, and memory of (N, subgraph_size)
+#                           drops to half.
+#   - node_dim=20         : halved from 40; affects learned node
+#                           embedding only, not forward-pass activations.
+#   - layers=2            : default is 3.
+base_config = MTGNNConfig(
+    max_epochs=10,
+    batch_size=8,
+    early_stop=5,
+    conv_channels=16,
+    residual_channels=16,
+    skip_channels=32,
+    end_channels=64,
+    subgraph_size=10,
+    node_dim=20,
+    layers=2,
+)
+
+tuner = HyperparameterTuner(
+    model_factory=lambda: MTGNNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":            Categorical([1e-3, 5e-4]),
+        "conv_channels": Categorical([16, 32]),
+        "dropout":       Categorical([0.1, 0.3]),
+    },
+    strategy="grid",
+)
+print("[example] Starting hyperparameter grid search (8 trials)...")
+tuning_result = tuner.run()
+print("[example] Tuning complete.")
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    print("[example] Running final evaluation on test set with best config...")
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(MTGNNModel(), config=tuning_result.best.config)
+    print("[example] Final evaluation complete.")
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/ny_covid_staeformer_example.py
+++ b/examples/ny_covid_staeformer_example.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tune STAEFormer on NY COVID (county-level), then report test metrics.
+
+Pipeline:
+    1. Run a grid search over STAEFormer-specific hyperparameters,
+       scored by validation loss. The test set is NOT seen during this
+       phase.
+    2. Take the winning config and run the standard benchmark pipeline
+       once for an unbiased test-set evaluation.
+
+Dataset:
+    NYT COVID-19 county-level, 7-day-smoothed deaths aligned with the
+    14-day-lagged smoothed cases. Target: ``new_deaths_smooth``.
+    N = 3,212 counties, T = 1,138 days, D_in = 2.
+    Graph: haversine distances with a 150 km cutoff — ignored by
+    STAEFormer (the transformer + adaptive embedding do not use ``adj``).
+
+Memory notes:
+    Spatial self-attention in STAEFormer is O(N²·d) per head per layer.
+    With N=3,212 that is ~10M attention entries per head; at
+    ``model_dim``=104 and ``num_heads``=4 the per-layer attention tensor
+    is ~4·32·3212² ≈ 1.3 GB in fp32 for a batch of 32, before any of
+    the usual transformer constants. This is the single biggest OOM
+    risk in this benchmark. Knobs applied below:
+      - batch_size=2             : spatial attention scales with B·N²
+      - num_layers=1             : default is 3; each layer stacks
+                                   another N² attention.
+      - adaptive_embedding_dim=40: halved from 80. model_dim drops from
+                                   104 to 64, so num_heads {2, 4, 8}
+                                   all divide cleanly.
+      - feed_forward_dim=128     : halved from 256 for the same reason.
+
+    If you still OOM, lower ``batch_size`` to 1 or drop
+    ``adaptive_embedding_dim`` to 16.
+
+num_heads divisibility:
+    With this config, model_dim = input_embedding_dim (24) +
+    adaptive_embedding_dim (40) = 64. num_heads must divide 64, so we
+    search {2, 4, 8}.
+
+Usage:
+    python examples/ny_covid_staeformer_example.py
+"""
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
+
+WORKSPACE = "./benchmark_workspace"
+DATASET = "nyc-covid"
+
+print(f"[example] STAEFormer on {DATASET} — workspace={WORKSPACE}")
+
+base_config = STAEFormerConfig(
+    max_epochs=10,
+    batch_size=2,
+    early_stop=5,
+    adaptive_embedding_dim=40,
+    feed_forward_dim=128,
+    num_layers=1,
+)
+
+tuner = HyperparameterTuner(
+    model_factory=lambda: STAEFormerModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":         Categorical([1e-3, 5e-4]),
+        "num_layers": Categorical([1, 2]),
+        "num_heads":  Categorical([2, 4]),
+    },
+    strategy="grid",
+)
+print("[example] Starting hyperparameter grid search (8 trials)...")
+tuning_result = tuner.run()
+print("[example] Tuning complete.")
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    print("[example] Running final evaluation on test set with best config...")
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(STAEFormerModel(), config=tuning_result.best.config)
+    print("[example] Final evaluation complete.")
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/tuning/tuner.py
+++ b/tuning/tuner.py
@@ -51,6 +51,7 @@ Typical usage::
 
 from __future__ import annotations
 
+import gc
 import itertools
 import random
 import time
@@ -63,6 +64,30 @@ from gnn_benchmark.benchmark import BenchmarkRunner, PreparedDataset
 from gnn_benchmark.core.workspace import DataWorkspace
 from gnn_benchmark.models import BenchmarkModel, TrainingHistory
 from gnn_benchmark.tuning.search_space import Sampler
+
+try:
+    import torch
+    _TORCH_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _TORCH_AVAILABLE = False
+
+
+def _free_trial_state(model: BenchmarkModel | None) -> None:
+    """Release a trial's model and its cached GPU memory.
+
+    Tuning loops accumulate VRAM because each fit() builds a fresh model
+    + optimiser state + pinned DataLoader tensors and Python's GC does
+    not run between trials. For long grids on large graphs (NY COVID
+    with 3212 nodes is the worst offender) this is the difference
+    between finishing the sweep and OOM-ing trial 4.
+    """
+    if model is not None:
+        del model
+    gc.collect()
+    if _TORCH_AVAILABLE and torch.cuda.is_available():
+        torch.cuda.empty_cache()
+        # ipc_collect is cheap and helps when workers pinned memory.
+        torch.cuda.ipc_collect()
 
 
 # ---------------------------------------------------------------------------
@@ -293,6 +318,7 @@ class HyperparameterTuner:
             best_val: float | None = None
             error: str | None = None
 
+            model: BenchmarkModel | None = None
             try:
                 model = self.model_factory()
                 history = model.fit(
@@ -314,6 +340,8 @@ class HyperparameterTuner:
                 error = f"{type(exc).__name__}: {exc}"
                 if self.verbose:
                     traceback.print_exc()
+            finally:
+                _free_trial_state(model)
 
             duration = time.time() - start
             trial = TrialResult(


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for the NY COVID-19 county-level dataset, including data preprocessing (7-day smoothing and 14-day case lagging), graph connectivity analysis, and example tuning scripts for multiple GNN models.

## Key Changes

### Dataset Implementation (`datasets/ny_covid.py`)
- Added `NYCovidLoader` class to download and process NYT COVID-19 county-level data
- Implemented 7-day backward rolling window smoothing to reduce reporting noise
- Implemented 14-day case lag alignment so cases at t-14 pair with deaths at t (epidemiological lag)
- Added haversine distance-based county adjacency graph with 150 km cutoff to balance connectivity and sparsity
- Target changed from cases to deaths (`new_deaths_smooth`) with cases as lagged input feature
- Includes FIPS coordinate geolocation and synthetic NYC aggregation

### Exploratory Analysis (`examples/ny_covid_explore.py`)
- Comprehensive exploratory script analyzing 3,212 US counties over 1,138 days
- Added connectivity analysis functions:
  - `connectivity_analysis()`: Kruskal-style sweep to find distance cutoffs for no isolated nodes and full connectivity
  - `plot_connectivity_curve()`: Visualizes connected components vs distance cutoff
  - `plot_isolation_curve()`: Shows isolated node count across cutoff range with elbow detection
  - `_UnionFind`: Efficient union-find data structure for component tracking
- Added diagnostics framework (`run_diagnostics()`, `detect_spike_counties()`) to flag training issues
- Updated all plots and statistics to use smoothed, lag-aligned columns
- Generates 10 PNG figures plus detailed text summary with connectivity and diagnostic reports

### Example Tuning Scripts
Added four new model-specific tuning examples for NY COVID dataset:
- `ny_covid_mtgnn_example.py`: MTGNN with reduced node_dim and subgraph_size for memory efficiency
- `ny_covid_staeformer_example.py`: STAEFormer with aggressive memory optimizations (batch_size=2, single layer)
- `ny_covid_gwn_example.py`: Graph WaveNet with halved hidden width and reduced blocks
- `ny_covid_d2stgnn_example.py`: D2STGNN with reduced hidden dimension and batch size

All examples include detailed memory notes explaining the 4× reduction in batch size and model width compared to LamaH-CE due to the 4× larger node count.

### Tuning Infrastructure (`tuning/tuner.py`)
- Added `_free_trial_state()` function to explicitly release GPU memory between trials
- Prevents VRAM accumulation during long hyperparameter sweeps on large graphs
- Calls `gc.collect()` and `torch.cuda.empty_cache()` after each trial

### Documentation Updates
- Updated `lamah_ce_dynamic_staeformer_example.py` with memory notes and reduced grid size (18 → 8 trials)
- Updated `lamah_ce_dynamic_d2stgnn_example.py` with memory notes and reduced batch size (32 → 16)
- Updated `.gitignore` to exclude benchmark workspace and example output directories

## Notable Implementation Details

- **Connectivity sweep**: Uses sorted edges and union-find to efficiently compute connected components at every distance threshold, enabling identification of critical distance cutoffs
- **Isolation detection**: Tracks first-neighbor distance per node to compute isolated node count at any cutoff without recomputing the full graph
- **Lag alignment**: Cases are shifted forward 14 days at the loader level; the first 14 days of deaths and last 14 days of cases are trimmed to ensure all rows have both aligned signals
- **Memory optimization**: All NY COVID examples use aggressive batch size and width reductions (batch_size=2-8 vs 16-32 for LamaH-CE) to fit 3,212 nodes on 12 GB GPUs
- **Diagnostics**: Flags zero-heavy counties, spike anomalies, isolated nodes, and disconnected components to warn users of potential training issues

https://claude.ai/code/session_01TqoiSSkR6qLQx1knefD8DR