### PR TITLE
Add hyperparameter tuning to EU load example scripts

### DIFF
--- a/examples/eu_load_d2stgnn_example.py
+++ b/examples/eu_load_d2stgnn_example.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run D2STGNN on the EU load dataset (no hyperparameter tuning).
+"""Tune D2STGNN on the EU load dataset, then report test metrics.
+
+Pipeline:
+    1. Run a grid search over D2STGNN-specific hyperparameters, scored by
+       validation loss.  The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline once
+       for an unbiased test-set evaluation.
 
 Dataset:
     ENTSO-E European zonal electricity load (hourly, 2023-2024).  49 nodes
@@ -7,16 +13,9 @@ Dataset:
     Edges are undirected, unweighted cross-zone interconnections.  Loader
     auto-downloads both files from Google Drive on first use.
 
-Hyperparameters (no grid search):
-    Sticking with D2STGNN's defaults — for a 49-node graph with a single
-    feature, the default num_hidden=32 is sufficient.  D2STGNN's default
-    learning rate (2e-3) is higher than the other models and works well
-    with the MultiStep LR scheduler that's enabled by default.  Only the
-    training-budget knobs (max_epochs, batch_size, early_stop) are
-    touched: max_epochs is bumped to 50 since we run a single trial
-    instead of a grid.
-
 D2STGNN consumes the interconnection adjacency via doubletransition.
+
+Grid is 2 x 3 x 3 = 18 trials.
 
 Usage:
     python examples/eu_load_d2stgnn_example.py
@@ -24,21 +23,45 @@ Usage:
 
 from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
 
 WORKSPACE = "./benchmark_workspace"
 DATASET = "eu-load"
 
 print(f"[example] D2STGNN on {DATASET} — workspace={WORKSPACE}")
 
-config = D2STGNNConfig(
-    lr=2e-3,
-    num_hidden=32,
-    dropout=0.1,
+base_config = D2STGNNConfig(
+    max_epochs=10,
     batch_size=32,
-    max_epochs=50,
-    early_stop=10,
+    early_stop=5,
 )
 
-runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
-result = runner.run(D2STGNNModel(), config=config)
-print(result.summary())
+# D2STGNN-specific search space (2 x 3 x 3 = 18 trials).
+# - lr         : D2STGNN's default (2e-3) is higher than GWN/MTGNN
+# - num_hidden : hidden channel width — the main capacity knob
+# - dropout    : regularisation; D2STGNN uses a lower default (0.1)
+tuner = HyperparameterTuner(
+    model_factory=lambda: D2STGNNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":         Categorical([2e-3, 1e-3]),
+        "num_hidden": Categorical([16, 32, 64]),
+        "dropout":    Categorical([0.1, 0.2, 0.3]),
+    },
+    strategy="grid",
+)
+print("[example] Starting hyperparameter grid search (18 trials)...")
+tuning_result = tuner.run()
+print("[example] Tuning complete.")
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    print("[example] Running final evaluation on test set with best config...")
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(D2STGNNModel(), config=tuning_result.best.config)
+    print("[example] Final evaluation complete.")
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/eu_load_gwn_example.py
+++ b/examples/eu_load_gwn_example.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run Graph WaveNet on the EU load dataset (no hyperparameter tuning).
+"""Tune Graph WaveNet on the EU load dataset, then report test metrics.
+
+Pipeline:
+    1. Run a grid search over GWN-specific hyperparameters, scored by
+       validation loss.  The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline once
+       for an unbiased test-set evaluation.
 
 Dataset:
     ENTSO-E European zonal electricity load (hourly, 2023-2024).  49 nodes
@@ -8,14 +14,9 @@ Dataset:
     if connected, 0 otherwise).  Loader auto-downloads both files from
     Google Drive on first use.
 
-Hyperparameters (no grid search):
-    Sticking with GWN's defaults — for a 49-node graph with a single
-    feature, the default capacity (nhid=32) is plenty and the default
-    1e-3 lr / 0.3 dropout converge cleanly.  Only the training-budget
-    knobs (max_epochs, batch_size, early_stop) are touched: max_epochs
-    is bumped to 50 since we run a single trial instead of a grid.
-
 GWN consumes the interconnection adjacency.
+
+Grid is 2 x 3 x 3 = 18 trials.
 
 Usage:
     python examples/eu_load_gwn_example.py
@@ -23,21 +24,45 @@ Usage:
 
 from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import GWNConfig, GWNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
 
 WORKSPACE = "./benchmark_workspace"
 DATASET = "eu-load"
 
 print(f"[example] GWN on {DATASET} — workspace={WORKSPACE}")
 
-config = GWNConfig(
-    lr=1e-3,
-    nhid=32,
-    dropout=0.3,
-    batch_size=64,
-    max_epochs=50,
-    early_stop=10,
+base_config = GWNConfig(
+    max_epochs=10,
+    batch_size=32,
+    early_stop=5,
 )
 
-runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
-result = runner.run(GWNModel(), config=config)
-print(result.summary())
+# GWN-specific search space (2 x 3 x 3 = 18 trials).
+# - lr      : training signal (log-scale pair)
+# - dropout : regularisation
+# - nhid    : hidden channel width — the main capacity knob
+tuner = HyperparameterTuner(
+    model_factory=lambda: GWNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":      Categorical([1e-3, 5e-4]),
+        "dropout": Categorical([0.1, 0.3, 0.5]),
+        "nhid":    Categorical([16, 32, 64]),
+    },
+    strategy="grid",
+)
+print("[example] Starting hyperparameter grid search (18 trials)...")
+tuning_result = tuner.run()
+print("[example] Tuning complete.")
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    print("[example] Running final evaluation on test set with best config...")
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(GWNModel(), config=tuning_result.best.config)
+    print("[example] Final evaluation complete.")
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/eu_load_mtgnn_example.py
+++ b/examples/eu_load_mtgnn_example.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run MTGNN on the EU load dataset (no hyperparameter tuning).
+"""Tune MTGNN on the EU load dataset, then report test metrics.
+
+Pipeline:
+    1. Run a grid search over MTGNN-specific hyperparameters, scored by
+       validation loss.  The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline once
+       for an unbiased test-set evaluation.
 
 Dataset:
     ENTSO-E European zonal electricity load (hourly, 2023-2024).  49 nodes
@@ -7,15 +13,10 @@ Dataset:
     Edges are undirected, unweighted cross-zone interconnections.  Loader
     auto-downloads both files from Google Drive on first use.
 
-Hyperparameters (no grid search):
-    Sticking with MTGNN's defaults — for a 49-node graph with a single
-    feature, the default conv_channels=32 is sufficient and 1e-3 lr /
-    0.3 dropout converge cleanly.  Only the training-budget knobs
-    (max_epochs, batch_size, early_stop) are touched: max_epochs is
-    bumped to 50 since we run a single trial instead of a grid.
-
 Note:
     MTGNN learns its own graph and ignores the supplied adjacency.
+
+Grid is 2 x 3 x 3 = 18 trials.
 
 Usage:
     python examples/eu_load_mtgnn_example.py
@@ -23,21 +24,45 @@ Usage:
 
 from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import MTGNNConfig, MTGNNModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
 
 WORKSPACE = "./benchmark_workspace"
 DATASET = "eu-load"
 
 print(f"[example] MTGNN on {DATASET} — workspace={WORKSPACE}")
 
-config = MTGNNConfig(
-    lr=1e-3,
-    conv_channels=32,
-    dropout=0.3,
-    batch_size=64,
-    max_epochs=50,
-    early_stop=10,
+base_config = MTGNNConfig(
+    max_epochs=10,
+    batch_size=32,
+    early_stop=5,
 )
 
-runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
-result = runner.run(MTGNNModel(), config=config)
-print(result.summary())
+# MTGNN-specific search space (2 x 3 x 3 = 18 trials).
+# - lr            : training signal (log-scale pair)
+# - conv_channels : width of the core TCN/GCN stack — the main capacity knob
+# - dropout       : regularisation
+tuner = HyperparameterTuner(
+    model_factory=lambda: MTGNNModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":            Categorical([1e-3, 5e-4]),
+        "conv_channels": Categorical([16, 32, 64]),
+        "dropout":       Categorical([0.1, 0.3, 0.5]),
+    },
+    strategy="grid",
+)
+print("[example] Starting hyperparameter grid search (18 trials)...")
+tuning_result = tuner.run()
+print("[example] Tuning complete.")
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    print("[example] Running final evaluation on test set with best config...")
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(MTGNNModel(), config=tuning_result.best.config)
+    print("[example] Final evaluation complete.")
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")

--- a/examples/eu_load_staeformer_example.py
+++ b/examples/eu_load_staeformer_example.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Run STAEFormer on the EU load dataset (no hyperparameter tuning).
+"""Tune STAEFormer on the EU load dataset, then report test metrics.
+
+Pipeline:
+    1. Run a grid search over STAEFormer-specific hyperparameters, scored
+       by validation loss.  The test set is NOT seen during this phase.
+    2. Take the winning config and run the standard benchmark pipeline
+       once for an unbiased test-set evaluation.
 
 Dataset:
     ENTSO-E European zonal electricity load (hourly, 2023-2024).  49 nodes
@@ -7,18 +13,14 @@ Dataset:
     Edges are undirected, unweighted cross-zone interconnections.  Loader
     auto-downloads both files from Google Drive on first use.
 
-Hyperparameters (no grid search):
-    Sticking with STAEFormer's defaults — for a 49-node graph with a
-    single feature, the default num_layers=3 / num_heads=4 transformer
-    is well-sized.  num_heads must divide model_dim; with this wrapper
-    model_dim = input_embedding_dim (24) + adaptive_embedding_dim (80)
-    = 104, and 4 divides 104.  Only the training-budget knobs
-    (max_epochs, batch_size, early_stop) are touched: max_epochs is
-    bumped to 50 since we run a single trial instead of a grid.
+Note on num_heads: in this wrapper tod/dow/spatial embedding dims are 0,
+so model_dim = input_embedding_dim (24) + adaptive_embedding_dim (80) =
+104.  num_heads must divide 104, which is why we search {2, 4, 8}.
 
-Note:
-    STAEFormer does not use the supplied graph — the transformer +
-    adaptive embedding ignore ``adj``.
+STAEFormer does not use the supplied graph — the transformer + adaptive
+embedding ignore `adj`.
+
+Grid is 2 x 3 x 3 = 18 trials.
 
 Usage:
     python examples/eu_load_staeformer_example.py
@@ -26,22 +28,45 @@ Usage:
 
 from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
+from gnn_benchmark.tuning import Categorical, HyperparameterTuner
 
 WORKSPACE = "./benchmark_workspace"
 DATASET = "eu-load"
 
 print(f"[example] STAEFormer on {DATASET} — workspace={WORKSPACE}")
 
-config = STAEFormerConfig(
-    lr=1e-3,
-    num_layers=3,
-    num_heads=4,
-    dropout=0.1,
+base_config = STAEFormerConfig(
+    max_epochs=10,
     batch_size=16,
-    max_epochs=50,
-    early_stop=10,
+    early_stop=5,
 )
 
-runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
-result = runner.run(STAEFormerModel(), config=config)
-print(result.summary())
+# STAEFormer-specific search space (2 x 3 x 3 = 18 trials).
+# - lr         : training signal (log-scale pair)
+# - num_layers : transformer depth — the main capacity knob
+# - num_heads  : attention heads; all values must divide model_dim (104)
+tuner = HyperparameterTuner(
+    model_factory=lambda: STAEFormerModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    workspace_dir=WORKSPACE,
+    search_space={
+        "lr":         Categorical([1e-3, 5e-4]),
+        "num_layers": Categorical([2, 3, 4]),
+        "num_heads":  Categorical([2, 4, 8]),
+    },
+    strategy="grid",
+)
+print("[example] Starting hyperparameter grid search (18 trials)...")
+tuning_result = tuner.run()
+print("[example] Tuning complete.")
+print(tuning_result.summary())
+
+if tuning_result.best is not None:
+    print("[example] Running final evaluation on test set with best config...")
+    runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+    final = runner.run(STAEFormerModel(), config=tuning_result.best.config)
+    print("[example] Final evaluation complete.")
+    print(final.summary())
+else:
+    print("No successful trials — skipping final evaluation.")


### PR DESCRIPTION
## Summary
Refactored all four EU load example scripts (GWN, MTGNN, D2STGNN, STAEFormer) to implement a two-stage pipeline: hyperparameter grid search followed by final test-set evaluation with the best configuration.

## Key Changes
- **Introduced `HyperparameterTuner`**: All examples now use the tuning framework to perform grid search over model-specific hyperparameters, with validation loss as the scoring metric
- **Standardized search spaces**: Each model searches a 2×3×3 = 18-trial grid covering:
  - Learning rate (2 values, log-scale pairs)
  - Model capacity knob (3 values: 16/32/64 or equivalent)
  - Regularization/architecture parameter (3 values)
- **Two-stage evaluation pipeline**:
  1. Grid search phase: Hyperparameter tuning on validation set (test set unseen)
  2. Final evaluation: Single benchmark run with best config for unbiased test metrics
- **Reduced training budgets**: Lowered `max_epochs` from 50→10 and `early_stop` from 10→5 for faster grid search iterations
- **Improved documentation**: Updated docstrings to explain the tuning pipeline and search space rationale for each model

## Implementation Details
- All examples follow the same pattern: create `base_config`, instantiate `HyperparameterTuner` with search space, run tuning, then conditionally run final benchmark with best config
- Search space parameters are model-specific (e.g., `nhid` for GWN, `conv_channels` for MTGNN, `num_heads` for STAEFormer)
- Graceful handling of failed tuning runs with fallback message

https://claude.ai/code/session_017aonX1zepAnTwcVQVk2C3y