### PR TITLE
Add compute-time tracking and NaN-aware loss across all models

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -91,6 +91,7 @@ from gnn_benchmark.utils.data import (
 )
 from gnn_benchmark.models import BenchmarkModel
 from gnn_benchmark.utils.metrics import mae, mape, rmse
+from gnn_benchmark.utils.timing import ComputeTimer
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +180,9 @@ class DatasetResult:
         mape:         Mean Absolute Percentage Error (0–100 scale).
         per_horizon:  Per-step metrics ``{step: {"mae": ..., "rmse": ..., "mape": ...}}``
                       for every horizon step h=1..H.
+        train_time_sec:     Wall-clock seconds spent inside ``model.fit``
+                            (data loading already done; pure compute budget).
+        inference_time_sec: Wall-clock seconds spent inside ``model.predict``.
         error:        Exception message if this dataset failed; other fields are ``None``.
     """
 
@@ -187,6 +191,8 @@ class DatasetResult:
     rmse: float | None = None
     mape: float | None = None
     per_horizon: dict[int, dict[str, float]] = field(default_factory=dict)
+    train_time_sec: float | None = None
+    inference_time_sec: float | None = None
     error: str | None = None
 
 
@@ -199,11 +205,15 @@ class BenchmarkResult:
         model_name:      Value of ``BenchmarkModel.name``.
         model_config:    Dict returned by ``BenchmarkModel.get_config()``.
         dataset_results: Mapping from dataset key to ``DatasetResult``.
+        tuning_compute_time_sec: Total seconds spent inside ``model.fit``
+            during hyperparameter tuning, when this benchmark run was
+            preceded by a tuning sweep. ``None`` for a vanilla evaluation.
     """
 
     model_name: str
     model_config: dict = field(default_factory=dict)
     dataset_results: dict[str, DatasetResult] = field(default_factory=dict)
+    tuning_compute_time_sec: float | None = None
 
     # Horizons highlighted in the per-dataset table
     _DISPLAY_HORIZONS = (1, 3, 6, 12)
@@ -252,6 +262,20 @@ class BenchmarkResult:
                 f"{'Avg':<10} {r.mae:>9.4f} {r.rmse:>9.4f} {r.mape:>8.2f}%"
             )
 
+            # Compute-budget block — pure model.fit / model.predict time
+            # so different models are comparable on the same hardware.
+            if r.train_time_sec is not None or r.inference_time_sec is not None:
+                lines.append(thin)
+                tt = (
+                    f"{r.train_time_sec:.2f}s" if r.train_time_sec is not None else "—"
+                )
+                it = (
+                    f"{r.inference_time_sec:.2f}s"
+                    if r.inference_time_sec is not None
+                    else "—"
+                )
+                lines.append(f"compute   train={tt}  inference={it}")
+
             mae_vals.append(r.mae)
             rmse_vals.append(r.rmse)
             mape_vals.append(r.mape)
@@ -269,6 +293,48 @@ class BenchmarkResult:
                 f" {np.mean(mape_vals):>8.2f}%"
             )
 
+        # Compute-budget aggregate so the report can answer "how much
+        # GPU time did this model cost end-to-end".
+        train_times = [
+            r.train_time_sec
+            for r in self.dataset_results.values()
+            if r.train_time_sec is not None
+        ]
+        infer_times = [
+            r.inference_time_sec
+            for r in self.dataset_results.values()
+            if r.inference_time_sec is not None
+        ]
+        if train_times or infer_times or self.tuning_compute_time_sec is not None:
+            lines.append(thick)
+            lines.append("Compute budget (seconds)")
+            lines.append(thin)
+            if self.tuning_compute_time_sec is not None:
+                lines.append(
+                    f"  hyperparameter search (sum of trial fit times): "
+                    f"{self.tuning_compute_time_sec:.2f}s"
+                )
+            if train_times:
+                lines.append(
+                    f"  training   (sum across datasets): "
+                    f"{sum(train_times):.2f}s"
+                )
+            if infer_times:
+                lines.append(
+                    f"  inference  (sum across datasets): "
+                    f"{sum(infer_times):.2f}s"
+                )
+
+        # Full configuration so the table is self-contained for results
+        # reporting — every hyperparameter that produced these numbers
+        # is on the page.
+        if self.model_config:
+            lines.append(thick)
+            lines.append("Model configuration")
+            lines.append(thin)
+            for key in sorted(self.model_config):
+                lines.append(f"  {key} = {self.model_config[key]!r}")
+
         lines.append(thick)
         lines.append("(metrics in original units)")
         return "\n".join(lines)
@@ -278,12 +344,15 @@ class BenchmarkResult:
         return {
             "model_name": self.model_name,
             "model_config": self.model_config,
+            "tuning_compute_time_sec": self.tuning_compute_time_sec,
             "datasets": {
                 name: {
                     "mae": r.mae,
                     "rmse": r.rmse,
                     "mape": r.mape,
                     "per_horizon": r.per_horizon,
+                    "train_time_sec": r.train_time_sec,
+                    "inference_time_sec": r.inference_time_sec,
                     "error": r.error,
                 }
                 for name, r in self.dataset_results.items()
@@ -336,6 +405,7 @@ class BenchmarkRunner:
         self,
         model: BenchmarkModel,
         config: Any = None,
+        tuning_compute_time_sec: float | None = None,
     ) -> BenchmarkResult:
         """
         Run the full benchmark for all configured datasets.
@@ -354,6 +424,11 @@ class BenchmarkRunner:
         Args:
             model:  A fitted or unfitted ``BenchmarkModel`` instance.
             config: Opaque config object forwarded to ``fit`` and ``predict``.
+            tuning_compute_time_sec:
+                Optional. When this run follows a hyperparameter sweep,
+                pass ``tuning_result.total_compute_time_sec`` so the
+                printed report attributes the search cost alongside the
+                final training and inference costs.
 
         Returns:
             ``BenchmarkResult`` with per-dataset and aggregate metrics.
@@ -367,6 +442,7 @@ class BenchmarkRunner:
         result = BenchmarkResult(
             model_name=model.name,
             model_config=model.get_config(),
+            tuning_compute_time_sec=tuning_compute_time_sec,
         )
 
         workspace = DataWorkspace(self.workspace_dir)
@@ -387,10 +463,26 @@ class BenchmarkRunner:
             if dr.error:
                 self._log(f"[{dataset_key}] FAILED — {dr.error}")
             else:
+                tt = (
+                    f"  train={dr.train_time_sec:.1f}s"
+                    if dr.train_time_sec is not None
+                    else ""
+                )
+                it = (
+                    f"  infer={dr.inference_time_sec:.2f}s"
+                    if dr.inference_time_sec is not None
+                    else ""
+                )
                 self._log(
                     f"[{dataset_key}] Done  "
-                    f"MAE={dr.mae:.4f}  RMSE={dr.rmse:.4f}  MAPE={dr.mape:.2f}%"
+                    f"MAE={dr.mae:.4f}  RMSE={dr.rmse:.4f}  "
+                    f"MAPE={dr.mape:.2f}%{tt}{it}"
                 )
+
+        # Refresh model_config after the final fit so the report's
+        # configuration block reflects the hyperparameters that produced
+        # the printed metrics.
+        result.model_config = model.get_config() or result.model_config
 
         return result
 
@@ -479,17 +571,19 @@ class BenchmarkRunner:
     ) -> DatasetResult:
         prepared = self.prepare_dataset(workspace, dataset_key)
 
-        # 7. Fit
+        # 7. Fit (timed: pure compute, data prep above is excluded)
         self._log(f"[{dataset_key}] Fitting model …")
-        model.fit(
-            prepared.x_train, prepared.y_train,
-            prepared.x_val, prepared.y_val,
-            prepared.adj, config,
-        )
+        with ComputeTimer() as train_timer:
+            model.fit(
+                prepared.x_train, prepared.y_train,
+                prepared.x_val, prepared.y_val,
+                prepared.adj, config,
+            )
 
-        # 8. Predict
+        # 8. Predict (timed)
         self._log(f"[{dataset_key}] Predicting …")
-        y_pred = model.predict(prepared.x_test, prepared.adj, config)
+        with ComputeTimer() as infer_timer:
+            y_pred = model.predict(prepared.x_test, prepared.adj, config)
         y_pred = np.asarray(y_pred)
 
         y_test = prepared.y_test
@@ -526,6 +620,8 @@ class BenchmarkRunner:
             rmse=dataset_rmse,
             mape=dataset_mape,
             per_horizon=per_horizon,  # always populated (h=1..horizon)
+            train_time_sec=train_timer.elapsed,
+            inference_time_sec=infer_timer.elapsed,
         )
 
     def _log(self, msg: str) -> None:

--- a/benchmark.py
+++ b/benchmark.py
@@ -91,7 +91,7 @@ from gnn_benchmark.utils.data import (
 )
 from gnn_benchmark.models import BenchmarkModel
 from gnn_benchmark.utils.metrics import mae, mape, rmse
-from gnn_benchmark.utils.timing import ComputeTimer
+from gnn_benchmark.utils.timing import WallTimer
 
 
 # ---------------------------------------------------------------------------
@@ -180,9 +180,17 @@ class DatasetResult:
         mape:         Mean Absolute Percentage Error (0–100 scale).
         per_horizon:  Per-step metrics ``{step: {"mae": ..., "rmse": ..., "mape": ...}}``
                       for every horizon step h=1..H.
-        train_time_sec:     Wall-clock seconds spent inside ``model.fit``
-                            (data loading already done; pure compute budget).
-        inference_time_sec: Wall-clock seconds spent inside ``model.predict``.
+        train_compute_sec:     Pure compute seconds inside ``model.fit`` —
+                               forward + backward + step + criterion only,
+                               excluding DataLoader iteration and host↔device
+                               transfer. Reported by wrappers that override
+                               ``BenchmarkModel.get_train_compute_sec``;
+                               ``None`` for wrappers that don't.
+        inference_compute_sec: Same idea for ``model.predict``.
+        train_wall_sec:        Wall-clock seconds inside ``model.fit``,
+                               including DataLoader iteration and any data
+                               movement. Always populated.
+        inference_wall_sec:    Wall-clock seconds inside ``model.predict``.
         error:        Exception message if this dataset failed; other fields are ``None``.
     """
 
@@ -191,9 +199,23 @@ class DatasetResult:
     rmse: float | None = None
     mape: float | None = None
     per_horizon: dict[int, dict[str, float]] = field(default_factory=dict)
-    train_time_sec: float | None = None
-    inference_time_sec: float | None = None
+    train_compute_sec: float | None = None
+    inference_compute_sec: float | None = None
+    train_wall_sec: float | None = None
+    inference_wall_sec: float | None = None
     error: str | None = None
+
+    # Deprecated aliases — keep so external callers and JSON dumps that
+    # already read ``train_time_sec`` / ``inference_time_sec`` keep
+    # working.  These point at the wall-clock numbers (the previous
+    # behaviour) so historical reports remain comparable.
+    @property
+    def train_time_sec(self) -> float | None:
+        return self.train_wall_sec
+
+    @property
+    def inference_time_sec(self) -> float | None:
+        return self.inference_wall_sec
 
 
 @dataclass
@@ -262,19 +284,32 @@ class BenchmarkResult:
                 f"{'Avg':<10} {r.mae:>9.4f} {r.rmse:>9.4f} {r.mape:>8.2f}%"
             )
 
-            # Compute-budget block — pure model.fit / model.predict time
-            # so different models are comparable on the same hardware.
-            if r.train_time_sec is not None or r.inference_time_sec is not None:
+            # Compute-budget block — distinguish pure compute (forward
+            # + backward + step + criterion) from outer wall-clock so
+            # data-loading overhead does not muddy the cross-model
+            # comparison. Pure compute is what wrappers expose via
+            # ``Stopwatch``; wall is the timed ``model.fit``/``predict``
+            # call. The two will be equal for wrappers that have not
+            # opted into per-batch timing.
+            if (
+                r.train_wall_sec is not None
+                or r.inference_wall_sec is not None
+                or r.train_compute_sec is not None
+                or r.inference_compute_sec is not None
+            ):
                 lines.append(thin)
-                tt = (
-                    f"{r.train_time_sec:.2f}s" if r.train_time_sec is not None else "—"
+
+                def _fmt(v: float | None) -> str:
+                    return f"{v:.2f}s" if v is not None else "—"
+
+                lines.append(
+                    f"compute   train={_fmt(r.train_compute_sec)}  "
+                    f"inference={_fmt(r.inference_compute_sec)}"
                 )
-                it = (
-                    f"{r.inference_time_sec:.2f}s"
-                    if r.inference_time_sec is not None
-                    else "—"
+                lines.append(
+                    f"wall      train={_fmt(r.train_wall_sec)}  "
+                    f"inference={_fmt(r.inference_wall_sec)}"
                 )
-                lines.append(f"compute   train={tt}  inference={it}")
 
             mae_vals.append(r.mae)
             rmse_vals.append(r.rmse)
@@ -294,35 +329,67 @@ class BenchmarkResult:
             )
 
         # Compute-budget aggregate so the report can answer "how much
-        # GPU time did this model cost end-to-end".
-        train_times = [
-            r.train_time_sec
+        # GPU time did this model cost end-to-end". Both pure compute
+        # (per-batch Stopwatch) and outer wall-clock are summed so the
+        # gap reveals data-loading overhead.
+        def _sum_or_none(values: list[float]) -> float | None:
+            return sum(values) if values else None
+
+        train_compute = [
+            r.train_compute_sec
             for r in self.dataset_results.values()
-            if r.train_time_sec is not None
+            if r.train_compute_sec is not None
         ]
-        infer_times = [
-            r.inference_time_sec
+        infer_compute = [
+            r.inference_compute_sec
             for r in self.dataset_results.values()
-            if r.inference_time_sec is not None
+            if r.inference_compute_sec is not None
         ]
-        if train_times or infer_times or self.tuning_compute_time_sec is not None:
+        train_wall = [
+            r.train_wall_sec
+            for r in self.dataset_results.values()
+            if r.train_wall_sec is not None
+        ]
+        infer_wall = [
+            r.inference_wall_sec
+            for r in self.dataset_results.values()
+            if r.inference_wall_sec is not None
+        ]
+
+        if (
+            train_compute
+            or infer_compute
+            or train_wall
+            or infer_wall
+            or self.tuning_compute_time_sec is not None
+        ):
             lines.append(thick)
-            lines.append("Compute budget (seconds)")
+            lines.append("Compute budget (seconds, summed across datasets)")
             lines.append(thin)
             if self.tuning_compute_time_sec is not None:
                 lines.append(
                     f"  hyperparameter search (sum of trial fit times): "
                     f"{self.tuning_compute_time_sec:.2f}s"
                 )
-            if train_times:
+            tc = _sum_or_none(train_compute)
+            ic = _sum_or_none(infer_compute)
+            tw = _sum_or_none(train_wall)
+            iw = _sum_or_none(infer_wall)
+            if tc is not None or tw is not None:
                 lines.append(
-                    f"  training   (sum across datasets): "
-                    f"{sum(train_times):.2f}s"
+                    f"  training    compute={tc:.2f}s  wall={tw:.2f}s"
+                    if tc is not None and tw is not None
+                    else f"  training    wall={tw:.2f}s"
+                    if tw is not None
+                    else f"  training    compute={tc:.2f}s"
                 )
-            if infer_times:
+            if ic is not None or iw is not None:
                 lines.append(
-                    f"  inference  (sum across datasets): "
-                    f"{sum(infer_times):.2f}s"
+                    f"  inference   compute={ic:.2f}s  wall={iw:.2f}s"
+                    if ic is not None and iw is not None
+                    else f"  inference   wall={iw:.2f}s"
+                    if iw is not None
+                    else f"  inference   compute={ic:.2f}s"
                 )
 
         # Full configuration so the table is self-contained for results
@@ -351,8 +418,10 @@ class BenchmarkResult:
                     "rmse": r.rmse,
                     "mape": r.mape,
                     "per_horizon": r.per_horizon,
-                    "train_time_sec": r.train_time_sec,
-                    "inference_time_sec": r.inference_time_sec,
+                    "train_compute_sec": r.train_compute_sec,
+                    "inference_compute_sec": r.inference_compute_sec,
+                    "train_wall_sec": r.train_wall_sec,
+                    "inference_wall_sec": r.inference_wall_sec,
                     "error": r.error,
                 }
                 for name, r in self.dataset_results.items()
@@ -463,16 +532,20 @@ class BenchmarkRunner:
             if dr.error:
                 self._log(f"[{dataset_key}] FAILED — {dr.error}")
             else:
-                tt = (
-                    f"  train={dr.train_time_sec:.1f}s"
-                    if dr.train_time_sec is not None
-                    else ""
+                # Prefer the pure-compute number when the wrapper exposed
+                # one; fall back to wall-clock for legacy wrappers.
+                t_value = (
+                    dr.train_compute_sec
+                    if dr.train_compute_sec is not None
+                    else dr.train_wall_sec
                 )
-                it = (
-                    f"  infer={dr.inference_time_sec:.2f}s"
-                    if dr.inference_time_sec is not None
-                    else ""
+                i_value = (
+                    dr.inference_compute_sec
+                    if dr.inference_compute_sec is not None
+                    else dr.inference_wall_sec
                 )
+                tt = f"  train={t_value:.1f}s" if t_value is not None else ""
+                it = f"  infer={i_value:.2f}s" if i_value is not None else ""
                 self._log(
                     f"[{dataset_key}] Done  "
                     f"MAE={dr.mae:.4f}  RMSE={dr.rmse:.4f}  "
@@ -571,9 +644,11 @@ class BenchmarkRunner:
     ) -> DatasetResult:
         prepared = self.prepare_dataset(workspace, dataset_key)
 
-        # 7. Fit (timed: pure compute, data prep above is excluded)
+        # 7. Fit (timed). ``train_wall_sec`` is the outer wall-clock,
+        # which still includes DataLoader iteration. The wrapper-level
+        # ``Stopwatch`` accessor exposes pure compute time alongside.
         self._log(f"[{dataset_key}] Fitting model …")
-        with ComputeTimer() as train_timer:
+        with WallTimer() as train_timer:
             model.fit(
                 prepared.x_train, prepared.y_train,
                 prepared.x_val, prepared.y_val,
@@ -582,7 +657,7 @@ class BenchmarkRunner:
 
         # 8. Predict (timed)
         self._log(f"[{dataset_key}] Predicting …")
-        with ComputeTimer() as infer_timer:
+        with WallTimer() as infer_timer:
             y_pred = model.predict(prepared.x_test, prepared.adj, config)
         y_pred = np.asarray(y_pred)
 
@@ -620,8 +695,10 @@ class BenchmarkRunner:
             rmse=dataset_rmse,
             mape=dataset_mape,
             per_horizon=per_horizon,  # always populated (h=1..horizon)
-            train_time_sec=train_timer.elapsed,
-            inference_time_sec=infer_timer.elapsed,
+            train_wall_sec=train_timer.elapsed,
+            inference_wall_sec=infer_timer.elapsed,
+            train_compute_sec=model.get_train_compute_sec(),
+            inference_compute_sec=model.get_inference_compute_sec(),
         )
 
     def _log(self, msg: str) -> None:

--- a/models/astgcn.py
+++ b/models/astgcn.py
@@ -16,7 +16,7 @@ Usage::
 from __future__ import annotations
 
 import copy
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 import numpy as np
@@ -26,6 +26,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.ASTGCN.model.ASTGCN_r import ASTGCN
+from gnn_benchmark.utils.losses import masked_huber_loss
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +56,11 @@ class ASTGCNConfig:
     nb_chev_filter: int = 64
     nb_time_filter: int = 64
     time_strides: int = 1
+
+    # LR scheduler (multi-step decay — unified across all benchmark models)
+    use_lr_scheduler: bool = True
+    lr_milestones: list[int] = field(default_factory=lambda: [20, 40, 60, 80])
+    lr_decay_ratio: float = 0.5
 
     # Runtime
     seed: int | None = None
@@ -184,8 +190,9 @@ class ASTGCNModel(BenchmarkModel):
         # -- Normalize x and handle NaN ------------------------------------
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
         x_val_n = torch.nan_to_num(scaler.transform(x_val.to(device)))
-        y_train_d = torch.nan_to_num(y_train.to(device))
-        y_val_d = torch.nan_to_num(y_val.to(device))
+        # Targets keep NaN so masked_huber_loss can ignore them.
+        y_train_d = y_train.to(device)
+        y_val_d = y_val.to(device)
 
         # -- DataLoaders ---------------------------------------------------
         train_loader = DataLoader(
@@ -216,10 +223,17 @@ class ASTGCNModel(BenchmarkModel):
         ).to(device)
 
         # -- Training setup ------------------------------------------------
-        criterion = nn.HuberLoss()
+        criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
             model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
         )
+        scheduler = None
+        if cfg.use_lr_scheduler:
+            scheduler = torch.optim.lr_scheduler.MultiStepLR(
+                optimizer,
+                milestones=cfg.lr_milestones,
+                gamma=cfg.lr_decay_ratio,
+            )
 
         # -- Training loop -------------------------------------------------
         train_losses: list[float] = []
@@ -245,6 +259,8 @@ class ASTGCNModel(BenchmarkModel):
                     nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
                 optimizer.step()
                 batch_losses.append(loss.item())
+            if scheduler is not None:
+                scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             model.eval()

--- a/models/astgcn.py
+++ b/models/astgcn.py
@@ -27,6 +27,20 @@ from torch.utils.data import DataLoader, TensorDataset
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.ASTGCN.model.ASTGCN_r import ASTGCN
 from gnn_benchmark.utils.losses import masked_huber_loss
+from gnn_benchmark.utils.timing import Stopwatch
+
+
+def _fit_feature_scaler(
+    tensor: torch.Tensor, feature_dim: int, device: torch.device
+) -> "_FeatureScaler":
+    """NaN-aware per-feature z-score scaler fit (used for both x and y)."""
+    flat = tensor.reshape(-1, feature_dim)
+    mean = torch.nanmean(flat, dim=0)
+    diff_sq = (flat - mean) ** 2
+    count = (~torch.isnan(flat)).sum(dim=0).float()
+    std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
+    std = torch.clamp(std, min=1e-8)
+    return _FeatureScaler(mean, std).to(device)
 
 
 # ---------------------------------------------------------------------------
@@ -45,10 +59,11 @@ class ASTGCNConfig:
     # Training hyper-parameters
     lr: float = 0.001
     weight_decay: float = 0.0
+    eps: float = 1e-8                        # Adam epsilon
     batch_size: int = 32
     max_epochs: int = 80
     early_stop: int = 30
-    clip_grad: float | None = None
+    clip_grad: float | None = 5.0            # gradient-norm clip; None disables
 
     # Architecture (paper defaults)
     nb_block: int = 2
@@ -134,8 +149,11 @@ class ASTGCNModel(BenchmarkModel):
     def __init__(self) -> None:
         self._model: ASTGCN | None = None
         self._scaler: _FeatureScaler | None = None
+        self._y_scaler: _FeatureScaler | None = None
         self._device: torch.device | None = None
         self._cfg: ASTGCNConfig | None = None
+        self._train_compute_sec: float = 0.0
+        self._infer_compute_sec: float = 0.0
 
     # ---- BenchmarkModel interface ----------------------------------------
 
@@ -177,15 +195,11 @@ class ASTGCNModel(BenchmarkModel):
                 f"({cfg.time_strides})."
             )
 
-        # -- Fit scaler on x_train (per-feature, ignoring NaN) -------------
-        flat = x_train.reshape(-1, input_dim)
-        mean = torch.nanmean(flat, dim=0)
-        diff_sq = (flat - mean) ** 2
-        count = (~torch.isnan(flat)).sum(dim=0).float()
-        std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
-        std = torch.clamp(std, min=1e-8)
-        scaler = _FeatureScaler(mean, std).to(device)
+        # -- Fit scalers (per-feature z-score, NaN-aware) ------------------
+        scaler = _fit_feature_scaler(x_train, input_dim, device)
+        y_scaler = _fit_feature_scaler(y_train, output_dim, device)
         self._scaler = scaler
+        self._y_scaler = y_scaler
 
         # -- Normalize x and handle NaN ------------------------------------
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
@@ -225,7 +239,10 @@ class ASTGCNModel(BenchmarkModel):
         # -- Training setup ------------------------------------------------
         criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
-            model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
+            model.parameters(),
+            lr=cfg.lr,
+            weight_decay=cfg.weight_decay,
+            eps=cfg.eps,
         )
         scheduler = None
         if cfg.use_lr_scheduler:
@@ -236,6 +253,7 @@ class ASTGCNModel(BenchmarkModel):
             )
 
         # -- Training loop -------------------------------------------------
+        train_sw = Stopwatch()
         train_losses: list[float] = []
         val_losses: list[float] = []
         best_val_loss = float("inf")
@@ -246,32 +264,37 @@ class ASTGCNModel(BenchmarkModel):
             model.train()
             batch_losses: list[float] = []
             for x_batch, y_batch in train_loader:
-                # x_batch: (B, T, N, D) -> (B, N, D, T) for ASTGCN
-                x_in = x_batch.permute(0, 2, 3, 1)
-                out = model(x_in)  # (B, N, T_out, D_out)
-                out = out.permute(0, 2, 1, 3)  # (B, T_out, N, D_out)
-                out = scaler.inverse_transform(out)
-                loss = criterion(out, y_batch)
+                with train_sw:
+                    # x_batch: (B, T, N, D) -> (B, N, D, T) for ASTGCN
+                    x_in = x_batch.permute(0, 2, 3, 1)
+                    out = model(x_in)  # (B, N, T_out, D_out)
+                    out = out.permute(0, 2, 1, 3)  # (B, T_out, N, D_out)
+                    out = y_scaler.inverse_transform(out)
+                    loss = criterion(out, y_batch)
 
-                optimizer.zero_grad()
-                loss.backward()
-                if cfg.clip_grad:
-                    nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
-                optimizer.step()
-                batch_losses.append(loss.item())
-            if scheduler is not None:
-                scheduler.step()
+                    optimizer.zero_grad()
+                    loss.backward()
+                    if cfg.clip_grad:
+                        nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
+                    optimizer.step()
+                    batch_loss = loss.item()
+                batch_losses.append(batch_loss)
+            with train_sw:
+                if scheduler is not None:
+                    scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             model.eval()
             batch_losses_val: list[float] = []
             with torch.no_grad():
                 for x_batch, y_batch in val_loader:
-                    x_in = x_batch.permute(0, 2, 3, 1)
-                    out = model(x_in).permute(0, 2, 1, 3)
-                    out = scaler.inverse_transform(out)
-                    loss = criterion(out, y_batch)
-                    batch_losses_val.append(loss.item())
+                    with train_sw:
+                        x_in = x_batch.permute(0, 2, 3, 1)
+                        out = model(x_in).permute(0, 2, 1, 3)
+                        out = y_scaler.inverse_transform(out)
+                        loss = criterion(out, y_batch)
+                        batch_loss = loss.item()
+                    batch_losses_val.append(batch_loss)
             val_loss = float(np.mean(batch_losses_val))
             val_losses.append(val_loss)
 
@@ -287,6 +310,7 @@ class ASTGCNModel(BenchmarkModel):
         if best_state is not None:
             model.load_state_dict(best_state)
         self._model = model
+        self._train_compute_sec = train_sw.elapsed
 
         return TrainingHistory(train_loss=train_losses, val_loss=val_losses)
 
@@ -296,12 +320,13 @@ class ASTGCNModel(BenchmarkModel):
         adj: np.ndarray | None,
         config: Any,
     ) -> np.ndarray:
-        if self._model is None or self._scaler is None:
+        if self._model is None or self._scaler is None or self._y_scaler is None:
             raise RuntimeError("Call fit() before predict().")
 
         cfg = _resolve_config(config)
         device = self._device
         scaler = self._scaler
+        y_scaler = self._y_scaler
         model = self._model
 
         x_test_n = torch.nan_to_num(scaler.transform(x_test.to(device)))
@@ -312,18 +337,28 @@ class ASTGCNModel(BenchmarkModel):
             shuffle=False,
         )
 
+        infer_sw = Stopwatch()
         model.eval()
         preds: list[np.ndarray] = []
         with torch.no_grad():
             for (x_batch,) in loader:
-                x_in = x_batch.permute(0, 2, 3, 1)
-                out = model(x_in).permute(0, 2, 1, 3)
-                out = scaler.inverse_transform(out)
-                preds.append(out.cpu().numpy())
+                with infer_sw:
+                    x_in = x_batch.permute(0, 2, 3, 1)
+                    out = model(x_in).permute(0, 2, 1, 3)
+                    out = y_scaler.inverse_transform(out)
+                    out_cpu = out.cpu().numpy()
+                preds.append(out_cpu)
 
+        self._infer_compute_sec = infer_sw.elapsed
         return np.concatenate(preds, axis=0)
 
     def get_config(self) -> dict:
         if self._cfg is None:
             return {}
         return asdict(self._cfg)
+
+    def get_train_compute_sec(self) -> float | None:
+        return self._train_compute_sec or None
+
+    def get_inference_compute_sec(self) -> float | None:
+        return self._infer_compute_sec or None

--- a/models/base.py
+++ b/models/base.py
@@ -144,3 +144,21 @@ class BenchmarkModel(ABC):
         The default implementation returns an empty dict.
         """
         return {}
+
+    # ------------------------------------------------------------------
+    # Compute-budget accessors
+    # ------------------------------------------------------------------
+    # Wrappers that wrap their per-batch forward/backward/step span with
+    # a :class:`gnn_benchmark.utils.timing.Stopwatch` should override
+    # these to expose the *pure compute* total — excluding DataLoader
+    # iteration and host↔device transfers — so the benchmark report can
+    # compare models on equal footing regardless of how each one stages
+    # its tensors.  Return ``None`` to indicate the wrapper does not
+    # measure compute separately; the harness will then fall back to the
+    # outer wall-clock number.
+
+    def get_train_compute_sec(self) -> float | None:
+        return None
+
+    def get_inference_compute_sec(self) -> float | None:
+        return None

--- a/models/d2stgnn.py
+++ b/models/d2stgnn.py
@@ -26,6 +26,20 @@ from torch.utils.data import DataLoader, TensorDataset
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.D2STGNN.models.model import D2STGNN
 from gnn_benchmark.utils.losses import masked_huber_loss
+from gnn_benchmark.utils.timing import Stopwatch
+
+
+def _fit_feature_scaler(
+    tensor: torch.Tensor, feature_dim: int, device: torch.device
+) -> "_FeatureScaler":
+    """NaN-aware per-feature z-score scaler fit (used for both x and y)."""
+    flat = tensor.reshape(-1, feature_dim)
+    mean = torch.nanmean(flat, dim=0)
+    diff_sq = (flat - mean) ** 2
+    count = (~torch.isnan(flat)).sum(dim=0).float()
+    std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
+    std = torch.clamp(std, min=1e-8)
+    return _FeatureScaler(mean, std).to(device)
 
 
 # ---------------------------------------------------------------------------
@@ -44,11 +58,11 @@ class D2STGNNConfig:
     # Training hyper-parameters
     lr: float = 0.002
     weight_decay: float = 1e-5
-    eps: float = 1e-8
+    eps: float = 1e-8                        # Adam epsilon
     batch_size: int = 32
     max_epochs: int = 80
     early_stop: int = 30
-    clip_grad: float = 5.0
+    clip_grad: float | None = 5.0            # gradient-norm clip; None disables
 
     # Architecture (paper defaults)
     num_hidden: int = 32
@@ -198,10 +212,13 @@ class D2STGNNModel(BenchmarkModel):
     def __init__(self) -> None:
         self._model: D2STGNN | None = None
         self._scaler: _FeatureScaler | None = None
+        self._y_scaler: _FeatureScaler | None = None
         self._device: torch.device | None = None
         self._cfg: D2STGNNConfig | None = None
         self._out_steps: int | None = None
         self._output_dim: int | None = None
+        self._train_compute_sec: float = 0.0
+        self._infer_compute_sec: float = 0.0
 
     # ---- BenchmarkModel interface ----------------------------------------
 
@@ -236,16 +253,13 @@ class D2STGNNModel(BenchmarkModel):
         self._out_steps = out_steps
         self._output_dim = output_dim
 
-        # -- Fit scaler on x_train (per-feature, ignoring NaN) -------------
-        # Computed on CPU so we do not have to stage the full split on GPU.
-        flat = x_train.reshape(-1, input_dim)  # (S*T*N, D)
-        mean = torch.nanmean(flat, dim=0)      # (D,)
-        diff_sq = (flat - mean) ** 2
-        count = (~torch.isnan(flat)).sum(dim=0).float()
-        std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
-        std = torch.clamp(std, min=1e-8)
-        scaler = _FeatureScaler(mean, std).to(device)
+        # -- Fit scalers (per-feature z-score, NaN-aware) ------------------
+        # Separate y-scaler so inverse_transform uses target stats and
+        # never silently relies on "first D_out features are the targets".
+        scaler = _fit_feature_scaler(x_train, input_dim, device)
+        y_scaler = _fit_feature_scaler(y_train, output_dim, device)
         self._scaler = scaler
+        self._y_scaler = y_scaler
 
         # -- Build adjacency supports -------------------------------------
         adjs = _build_d2stgnn_adjs(adj, num_nodes, device)
@@ -306,6 +320,7 @@ class D2STGNNModel(BenchmarkModel):
             )
 
         # -- Training loop -------------------------------------------------
+        train_sw = Stopwatch()
         train_losses: list[float] = []
         val_losses: list[float] = []
         best_val_loss = float("inf")
@@ -317,22 +332,28 @@ class D2STGNNModel(BenchmarkModel):
             model.train()
             batch_losses: list[float] = []
             for x_batch, y_batch in train_loader:
+                # Host→device copy + scaling are NOT timed — they are data
+                # movement, not compute. Only the model evaluation, loss,
+                # backward and optimizer step contribute to the budget.
                 x_batch, y_batch = self._prepare_batch(
                     x_batch, y_batch, scaler, device,
                 )
-                out = model(x_batch)  # (B, out_steps, N, output_dim)
-                out = scaler.inverse_transform(out)
-                loss = criterion(out, y_batch)
+                with train_sw:
+                    out = model(x_batch)  # (B, out_steps, N, output_dim)
+                    out = y_scaler.inverse_transform(out)
+                    loss = criterion(out, y_batch)
 
-                optimizer.zero_grad()
-                loss.backward()
-                if cfg.clip_grad:
-                    nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
-                optimizer.step()
-                batch_losses.append(loss.item())
+                    optimizer.zero_grad()
+                    loss.backward()
+                    if cfg.clip_grad:
+                        nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
+                    optimizer.step()
+                    batch_loss = loss.item()
+                batch_losses.append(batch_loss)
 
-            if scheduler is not None:
-                scheduler.step()
+            with train_sw:
+                if scheduler is not None:
+                    scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             # ---- validate ----
@@ -343,10 +364,12 @@ class D2STGNNModel(BenchmarkModel):
                     x_batch, y_batch = self._prepare_batch(
                         x_batch, y_batch, scaler, device,
                     )
-                    out = model(x_batch)
-                    out = scaler.inverse_transform(out)
-                    loss = criterion(out, y_batch)
-                    batch_losses_val.append(loss.item())
+                    with train_sw:
+                        out = model(x_batch)
+                        out = y_scaler.inverse_transform(out)
+                        loss = criterion(out, y_batch)
+                        batch_loss = loss.item()
+                    batch_losses_val.append(batch_loss)
             val_loss = float(np.mean(batch_losses_val))
             val_losses.append(val_loss)
 
@@ -368,6 +391,7 @@ class D2STGNNModel(BenchmarkModel):
         if best_state is not None:
             model.load_state_dict(best_state)
         self._model = model
+        self._train_compute_sec = train_sw.elapsed
 
         if device.type == "cuda":
             torch.cuda.empty_cache()
@@ -380,12 +404,13 @@ class D2STGNNModel(BenchmarkModel):
         adj: np.ndarray | None,
         config: Any,
     ) -> np.ndarray:
-        if self._model is None or self._scaler is None:
+        if self._model is None or self._scaler is None or self._y_scaler is None:
             raise RuntimeError("Call fit() before predict().")
 
         cfg = _resolve_config(config)
         device = self._device
         scaler = self._scaler
+        y_scaler = self._y_scaler
         model = self._model
 
         pin = device.type == "cuda"
@@ -396,17 +421,23 @@ class D2STGNNModel(BenchmarkModel):
             pin_memory=pin,
         )
 
+        infer_sw = Stopwatch()
         model.eval()
         preds: list[np.ndarray] = []
         with torch.no_grad():
             for (x_batch,) in loader:
+                # Host→device transfer + scaling are excluded from the
+                # compute budget — only the model.forward call is timed.
                 x_batch = x_batch.to(device, non_blocking=pin)
                 x_batch = torch.nan_to_num(scaler.transform(x_batch))
                 x_batch = self._pad_time_features(x_batch)
-                out = model(x_batch)  # (B, out_steps, N, output_dim)
-                out = scaler.inverse_transform(out)
-                preds.append(out.cpu().numpy())
+                with infer_sw:
+                    out = model(x_batch)  # (B, out_steps, N, output_dim)
+                    out = y_scaler.inverse_transform(out)
+                    out_cpu = out.cpu().numpy()
+                preds.append(out_cpu)
 
+        self._infer_compute_sec = infer_sw.elapsed
         if device.type == "cuda":
             torch.cuda.empty_cache()
 
@@ -416,6 +447,12 @@ class D2STGNNModel(BenchmarkModel):
         if self._cfg is None:
             return {}
         return asdict(self._cfg)
+
+    def get_train_compute_sec(self) -> float | None:
+        return self._train_compute_sec or None
+
+    def get_inference_compute_sec(self) -> float | None:
+        return self._infer_compute_sec or None
 
     # ---- Private helpers -------------------------------------------------
 

--- a/models/d2stgnn.py
+++ b/models/d2stgnn.py
@@ -25,6 +25,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.D2STGNN.models.model import D2STGNN
+from gnn_benchmark.utils.losses import masked_huber_loss
 
 
 # ---------------------------------------------------------------------------
@@ -289,7 +290,7 @@ class D2STGNNModel(BenchmarkModel):
         model = D2STGNN(**model_args).to(device)
 
         # -- Training setup ------------------------------------------------
-        criterion = nn.HuberLoss()
+        criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
             model.parameters(),
             lr=cfg.lr,
@@ -435,7 +436,7 @@ class D2STGNNModel(BenchmarkModel):
         x_batch = x_batch.to(device, non_blocking=non_blocking)
         y_batch = y_batch.to(device, non_blocking=non_blocking)
         x_batch = torch.nan_to_num(scaler.transform(x_batch))
-        y_batch = torch.nan_to_num(y_batch)
+        # Targets keep NaN so masked_huber_loss can ignore missing positions.
         x_batch = cls._pad_time_features(x_batch)
         return x_batch, y_batch
 

--- a/models/gts.py
+++ b/models/gts.py
@@ -26,6 +26,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.GTS.model import GTSModel as _GTSNet
+from gnn_benchmark.utils.losses import masked_huber_loss
 
 
 # ---------------------------------------------------------------------------
@@ -233,8 +234,9 @@ class GTSModel(BenchmarkModel):
         # -- Normalize inputs and move to device --------------------------
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
         x_val_n = torch.nan_to_num(scaler.transform(x_val.to(device)))
-        y_train_d = torch.nan_to_num(y_train.to(device))
-        y_val_d = torch.nan_to_num(y_val.to(device))
+        # Targets keep NaN so masked_huber_loss can ignore missing positions.
+        y_train_d = y_train.to(device)
+        y_val_d = y_val.to(device)
 
         train_loader = DataLoader(
             TensorDataset(x_train_n, y_train_d),
@@ -272,7 +274,7 @@ class GTSModel(BenchmarkModel):
         ).to(device)
 
         # -- Training setup -----------------------------------------------
-        criterion = nn.HuberLoss()
+        criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
             model.parameters(), lr=cfg.lr, eps=cfg.eps,
         )
@@ -305,9 +307,15 @@ class GTSModel(BenchmarkModel):
                 seq = x_batch.permute(1, 0, 2, 3).reshape(
                     in_steps, -1, num_nodes * input_dim
                 )
-                # Teacher-forcing labels for curriculum learning:
+                # Teacher-forcing labels for curriculum learning. Decoder
+                # feedback cannot tolerate NaN, so the labels fed back into
+                # the model must be filled — but the loss below is still
+                # computed against the NaN-bearing ``y_batch`` so missing
+                # positions do not contribute to gradients.
                 # (B, T_out, N, D_out) -> (T_out, B, N*D_out)
-                lbl = y_batch[..., :output_dim].permute(1, 0, 2, 3).reshape(
+                lbl = torch.nan_to_num(
+                    y_batch[..., :output_dim]
+                ).permute(1, 0, 2, 3).reshape(
                     out_steps, -1, num_nodes * output_dim
                 )
 

--- a/models/gts.py
+++ b/models/gts.py
@@ -27,6 +27,20 @@ from torch.utils.data import DataLoader, TensorDataset
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.GTS.model import GTSModel as _GTSNet
 from gnn_benchmark.utils.losses import masked_huber_loss
+from gnn_benchmark.utils.timing import Stopwatch
+
+
+def _fit_feature_scaler(
+    tensor: torch.Tensor, feature_dim: int, device: torch.device
+) -> "_FeatureScaler":
+    """NaN-aware per-feature z-score scaler fit (used for both x and y)."""
+    flat = tensor.reshape(-1, feature_dim)
+    mean = torch.nanmean(flat, dim=0)
+    diff_sq = (flat - mean) ** 2
+    count = (~torch.isnan(flat)).sum(dim=0).float()
+    std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
+    std = torch.clamp(std, min=1e-8)
+    return _FeatureScaler(mean, std).to(device)
 
 
 # ---------------------------------------------------------------------------
@@ -44,11 +58,12 @@ class GTSConfig:
 
     # Training hyper-parameters
     lr: float = 0.005
-    eps: float = 1e-3
+    weight_decay: float = 0.0
+    eps: float = 1e-3                        # GTS-specific (paper default)
     batch_size: int = 64
     max_epochs: int = 100
     early_stop: int = 30
-    clip_grad: float = 5.0
+    clip_grad: float | None = 5.0            # gradient-norm clip; None disables
 
     # Architecture (paper defaults)
     rnn_units: int = 64
@@ -164,12 +179,15 @@ class GTSModel(BenchmarkModel):
     def __init__(self) -> None:
         self._model: _GTSNet | None = None
         self._scaler: _FeatureScaler | None = None
+        self._y_scaler: _FeatureScaler | None = None
         self._device: torch.device | None = None
         self._cfg: GTSConfig | None = None
         self._node_feas: torch.Tensor | None = None
         self._num_nodes: int | None = None
         self._out_steps: int | None = None
         self._output_dim: int | None = None
+        self._train_compute_sec: float = 0.0
+        self._infer_compute_sec: float = 0.0
 
     # ---- BenchmarkModel interface ----------------------------------------
 
@@ -205,15 +223,13 @@ class GTSModel(BenchmarkModel):
         self._out_steps = out_steps
         self._output_dim = output_dim
 
-        # -- Fit scaler on x_train (per-feature, ignoring NaN) -------------
-        flat = x_train.reshape(-1, input_dim)
-        mean = torch.nanmean(flat, dim=0)
-        diff_sq = (flat - mean) ** 2
-        count = (~torch.isnan(flat)).sum(dim=0).float()
-        std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
-        std = torch.clamp(std, min=1e-8)
-        scaler = _FeatureScaler(mean, std).to(device)
+        # -- Fit scalers (per-feature z-score, NaN-aware) ------------------
+        # Separate y-scaler so inverse_transform uses target stats and
+        # never silently relies on "first D_out features are the targets".
+        scaler = _fit_feature_scaler(x_train, input_dim, device)
+        y_scaler = _fit_feature_scaler(y_train, output_dim, device)
         self._scaler = scaler
+        self._y_scaler = y_scaler
 
         # -- Build node-feature pool for latent graph ---------------------
         node_feas = _build_node_feas(x_train, cfg.feas_len).to(device)
@@ -276,7 +292,10 @@ class GTSModel(BenchmarkModel):
         # -- Training setup -----------------------------------------------
         criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
-            model.parameters(), lr=cfg.lr, eps=cfg.eps,
+            model.parameters(),
+            lr=cfg.lr,
+            eps=cfg.eps,
+            weight_decay=cfg.weight_decay,
         )
         scheduler = None
         if cfg.use_lr_scheduler:
@@ -287,6 +306,7 @@ class GTSModel(BenchmarkModel):
             )
 
         # -- Training loop -------------------------------------------------
+        train_sw = Stopwatch()
         train_losses: list[float] = []
         val_losses: list[float] = []
         best_val_loss = float("inf")
@@ -303,57 +323,60 @@ class GTSModel(BenchmarkModel):
             model.train()
             batch_losses: list[float] = []
             for x_batch, y_batch in train_loader:
-                # (B, T, N, D) -> (T, B, N*D)
-                seq = x_batch.permute(1, 0, 2, 3).reshape(
-                    in_steps, -1, num_nodes * input_dim
-                )
-                # Teacher-forcing labels for curriculum learning. Decoder
-                # feedback cannot tolerate NaN, so the labels fed back into
-                # the model must be filled — but the loss below is still
-                # computed against the NaN-bearing ``y_batch`` so missing
-                # positions do not contribute to gradients.
-                # (B, T_out, N, D_out) -> (T_out, B, N*D_out)
-                lbl = torch.nan_to_num(
-                    y_batch[..., :output_dim]
-                ).permute(1, 0, 2, 3).reshape(
-                    out_steps, -1, num_nodes * output_dim
-                )
-
-                output, edge_probs = model(
-                    seq,
-                    node_feas,
-                    temp=cfg.temperature,
-                    gumbel_hard=True,
-                    labels=lbl,
-                    batches_seen=batches_seen,
-                )
-                # output: (T_out, B, N*D_out) -> (B, T_out, N, D_out)
-                output = output.reshape(
-                    out_steps, -1, num_nodes, output_dim
-                ).permute(1, 0, 2, 3)
-                output = scaler.inverse_transform(output)
-                loss_pred = criterion(output, y_batch)
-
-                if use_reg:
-                    probs = edge_probs.reshape(-1)
-                    true_edges = adj_ref.reshape(-1)
-                    loss_g = nn.functional.binary_cross_entropy(
-                        probs.clamp(1e-7, 1 - 1e-7), true_edges
+                with train_sw:
+                    # (B, T, N, D) -> (T, B, N*D)
+                    seq = x_batch.permute(1, 0, 2, 3).reshape(
+                        in_steps, -1, num_nodes * input_dim
                     )
-                    loss = loss_pred + cfg.bce_weight * loss_g
-                else:
-                    loss = loss_pred
+                    # Teacher-forcing labels for curriculum learning. Decoder
+                    # feedback cannot tolerate NaN, so the labels fed back
+                    # into the model must be filled — but the loss below is
+                    # still computed against the NaN-bearing ``y_batch`` so
+                    # missing positions do not contribute to gradients.
+                    # (B, T_out, N, D_out) -> (T_out, B, N*D_out)
+                    lbl = torch.nan_to_num(
+                        y_batch[..., :output_dim]
+                    ).permute(1, 0, 2, 3).reshape(
+                        out_steps, -1, num_nodes * output_dim
+                    )
 
-                optimizer.zero_grad()
-                loss.backward()
-                if cfg.clip_grad:
-                    nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
-                optimizer.step()
-                batch_losses.append(loss_pred.item())
+                    output, edge_probs = model(
+                        seq,
+                        node_feas,
+                        temp=cfg.temperature,
+                        gumbel_hard=True,
+                        labels=lbl,
+                        batches_seen=batches_seen,
+                    )
+                    # output: (T_out, B, N*D_out) -> (B, T_out, N, D_out)
+                    output = output.reshape(
+                        out_steps, -1, num_nodes, output_dim
+                    ).permute(1, 0, 2, 3)
+                    output = y_scaler.inverse_transform(output)
+                    loss_pred = criterion(output, y_batch)
+
+                    if use_reg:
+                        probs = edge_probs.reshape(-1)
+                        true_edges = adj_ref.reshape(-1)
+                        loss_g = nn.functional.binary_cross_entropy(
+                            probs.clamp(1e-7, 1 - 1e-7), true_edges
+                        )
+                        loss = loss_pred + cfg.bce_weight * loss_g
+                    else:
+                        loss = loss_pred
+
+                    optimizer.zero_grad()
+                    loss.backward()
+                    if cfg.clip_grad:
+                        nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
+                    optimizer.step()
+                    batch_loss = loss_pred.item()
+                batch_losses.append(batch_loss)
                 batches_seen += 1
 
-            if scheduler is not None:
-                scheduler.step()
+            with train_sw:
+                if scheduler is not None:
+                    scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             # ---- validate ----
@@ -361,20 +384,22 @@ class GTSModel(BenchmarkModel):
             batch_losses_val: list[float] = []
             with torch.no_grad():
                 for x_batch, y_batch in val_loader:
-                    seq = x_batch.permute(1, 0, 2, 3).reshape(
-                        in_steps, -1, num_nodes * input_dim
-                    )
-                    output, _ = model(
-                        seq,
-                        node_feas,
-                        temp=cfg.temperature,
-                        gumbel_hard=True,
-                    )
-                    output = output.reshape(
-                        out_steps, -1, num_nodes, output_dim
-                    ).permute(1, 0, 2, 3)
-                    output = scaler.inverse_transform(output)
-                    batch_losses_val.append(criterion(output, y_batch).item())
+                    with train_sw:
+                        seq = x_batch.permute(1, 0, 2, 3).reshape(
+                            in_steps, -1, num_nodes * input_dim
+                        )
+                        output, _ = model(
+                            seq,
+                            node_feas,
+                            temp=cfg.temperature,
+                            gumbel_hard=True,
+                        )
+                        output = output.reshape(
+                            out_steps, -1, num_nodes, output_dim
+                        ).permute(1, 0, 2, 3)
+                        output = y_scaler.inverse_transform(output)
+                        batch_loss = criterion(output, y_batch).item()
+                    batch_losses_val.append(batch_loss)
             val_loss = float(np.mean(batch_losses_val))
             val_losses.append(val_loss)
 
@@ -391,6 +416,7 @@ class GTSModel(BenchmarkModel):
         if best_state is not None:
             model.load_state_dict(best_state)
         self._model = model
+        self._train_compute_sec = train_sw.elapsed
 
         if device.type == "cuda":
             torch.cuda.empty_cache()
@@ -406,6 +432,7 @@ class GTSModel(BenchmarkModel):
         if (
             self._model is None
             or self._scaler is None
+            or self._y_scaler is None
             or self._node_feas is None
         ):
             raise RuntimeError("Call fit() before predict().")
@@ -413,6 +440,7 @@ class GTSModel(BenchmarkModel):
         cfg = _resolve_config(config)
         device = self._device
         scaler = self._scaler
+        y_scaler = self._y_scaler
         model = self._model
         num_nodes = self._num_nodes
         out_steps = self._out_steps
@@ -427,25 +455,29 @@ class GTSModel(BenchmarkModel):
             shuffle=False,
         )
 
+        infer_sw = Stopwatch()
         model.eval()
         preds: list[np.ndarray] = []
         with torch.no_grad():
             for (x_batch,) in loader:
-                seq = x_batch.permute(1, 0, 2, 3).reshape(
-                    in_steps, -1, num_nodes * input_dim
-                )
-                output, _ = model(
-                    seq,
-                    self._node_feas,
-                    temp=cfg.temperature,
-                    gumbel_hard=True,
-                )
-                output = output.reshape(
-                    out_steps, -1, num_nodes, output_dim
-                ).permute(1, 0, 2, 3)
-                output = scaler.inverse_transform(output)
-                preds.append(output.cpu().numpy())
+                with infer_sw:
+                    seq = x_batch.permute(1, 0, 2, 3).reshape(
+                        in_steps, -1, num_nodes * input_dim
+                    )
+                    output, _ = model(
+                        seq,
+                        self._node_feas,
+                        temp=cfg.temperature,
+                        gumbel_hard=True,
+                    )
+                    output = output.reshape(
+                        out_steps, -1, num_nodes, output_dim
+                    ).permute(1, 0, 2, 3)
+                    output = y_scaler.inverse_transform(output)
+                    out_cpu = output.cpu().numpy()
+                preds.append(out_cpu)
 
+        self._infer_compute_sec = infer_sw.elapsed
         if device.type == "cuda":
             torch.cuda.empty_cache()
 
@@ -455,3 +487,9 @@ class GTSModel(BenchmarkModel):
         if self._cfg is None:
             return {}
         return asdict(self._cfg)
+
+    def get_train_compute_sec(self) -> float | None:
+        return self._train_compute_sec or None
+
+    def get_inference_compute_sec(self) -> float | None:
+        return self._infer_compute_sec or None

--- a/models/gwn.py
+++ b/models/gwn.py
@@ -32,6 +32,24 @@ from gnn_benchmark.models.GWN.util import (
     sym_adj,
 )
 from gnn_benchmark.utils.losses import masked_huber_loss
+from gnn_benchmark.utils.timing import Stopwatch
+
+
+def _fit_feature_scaler(
+    tensor: torch.Tensor, feature_dim: int, device: torch.device
+) -> "_FeatureScaler":
+    """NaN-aware per-feature z-score scaler fit.
+
+    Shared with the y-scaler so prediction de-normalisation uses target
+    stats instead of the first ``D_out`` input-feature stats.
+    """
+    flat = tensor.reshape(-1, feature_dim)
+    mean = torch.nanmean(flat, dim=0)
+    diff_sq = (flat - mean) ** 2
+    count = (~torch.isnan(flat)).sum(dim=0).float()
+    std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
+    std = torch.clamp(std, min=1e-8)
+    return _FeatureScaler(mean, std).to(device)
 
 
 # ---------------------------------------------------------------------------
@@ -50,10 +68,11 @@ class GWNConfig:
     # Training hyper-parameters
     lr: float = 0.001
     weight_decay: float = 0.0001
+    eps: float = 1e-8                        # Adam epsilon
     batch_size: int = 64
     max_epochs: int = 100
     early_stop: int = 30
-    clip_grad: float = 5.0
+    clip_grad: float | None = 5.0            # gradient-norm clip; None disables
 
     # Architecture (paper defaults)
     nhid: int = 32
@@ -191,10 +210,13 @@ class GWNModel(BenchmarkModel):
     def __init__(self) -> None:
         self._model: gwnet | None = None
         self._scaler: _FeatureScaler | None = None
+        self._y_scaler: _FeatureScaler | None = None
         self._device: torch.device | None = None
         self._cfg: GWNConfig | None = None
         self._out_steps: int | None = None
         self._output_dim: int | None = None
+        self._train_compute_sec: float = 0.0
+        self._infer_compute_sec: float = 0.0
 
     # ---- BenchmarkModel interface ----------------------------------------
 
@@ -229,15 +251,13 @@ class GWNModel(BenchmarkModel):
         self._out_steps = out_steps
         self._output_dim = output_dim
 
-        # -- Fit scaler on x_train (per-feature, ignoring NaN) -------------
-        flat = x_train.reshape(-1, input_dim)  # (S*T*N, D)
-        mean = torch.nanmean(flat, dim=0)      # (D,)
-        diff_sq = (flat - mean) ** 2
-        count = (~torch.isnan(flat)).sum(dim=0).float()
-        std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
-        std = torch.clamp(std, min=1e-8)
-        scaler = _FeatureScaler(mean, std).to(device)
+        # -- Fit scalers (per-feature z-score, NaN-aware) ------------------
+        # Separate y-scaler so inverse_transform uses target stats and
+        # never silently relies on "first D_out features are the targets".
+        scaler = _fit_feature_scaler(x_train, input_dim, device)
+        y_scaler = _fit_feature_scaler(y_train, output_dim, device)
         self._scaler = scaler
+        self._y_scaler = y_scaler
 
         # -- Normalize x and handle NaN ------------------------------------
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
@@ -285,7 +305,10 @@ class GWNModel(BenchmarkModel):
         # -- Training setup ------------------------------------------------
         criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
-            model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
+            model.parameters(),
+            lr=cfg.lr,
+            weight_decay=cfg.weight_decay,
+            eps=cfg.eps,
         )
         scheduler = None
         if cfg.use_lr_scheduler:
@@ -296,6 +319,10 @@ class GWNModel(BenchmarkModel):
             )
 
         # -- Training loop -------------------------------------------------
+        # ``train_sw`` accumulates only the forward+backward+step compute
+        # span so the published per-model budget is not inflated by
+        # DataLoader iteration or host↔device transfer.
+        train_sw = Stopwatch()
         train_losses: list[float] = []
         val_losses: list[float] = []
         best_val_loss = float("inf")
@@ -307,29 +334,32 @@ class GWNModel(BenchmarkModel):
             model.train()
             batch_losses: list[float] = []
             for x_batch, y_batch in train_loader:
-                # x_batch: (B, T, N, D) -> (B, D, N, T) for gwnet
-                x_in = x_batch.permute(0, 3, 2, 1)
-                out = model(x_in)  # (B, out_steps*output_dim, N, T_out)
-                # T_out is 1 only when in_len <= receptive_field; otherwise the
-                # dilated convs leave a trailing window. Collapse by taking the
-                # last (most recent) step so the reshape preserves the batch dim.
-                out = (
-                    out[..., -1]
-                    .reshape(-1, out_steps, output_dim, num_nodes)
-                    .permute(0, 1, 3, 2)
-                )  # (B, out_steps, N, output_dim)
-                out = scaler.inverse_transform(out)
-                loss = criterion(out, y_batch)
+                with train_sw:
+                    # x_batch: (B, T, N, D) -> (B, D, N, T) for gwnet
+                    x_in = x_batch.permute(0, 3, 2, 1)
+                    out = model(x_in)  # (B, out_steps*output_dim, N, T_out)
+                    # T_out is 1 only when in_len <= receptive_field; otherwise the
+                    # dilated convs leave a trailing window. Collapse by taking the
+                    # last (most recent) step so the reshape preserves the batch dim.
+                    out = (
+                        out[..., -1]
+                        .reshape(-1, out_steps, output_dim, num_nodes)
+                        .permute(0, 1, 3, 2)
+                    )  # (B, out_steps, N, output_dim)
+                    out = y_scaler.inverse_transform(out)
+                    loss = criterion(out, y_batch)
 
-                optimizer.zero_grad()
-                loss.backward()
-                if cfg.clip_grad:
-                    nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
-                optimizer.step()
-                batch_losses.append(loss.item())
+                    optimizer.zero_grad()
+                    loss.backward()
+                    if cfg.clip_grad:
+                        nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
+                    optimizer.step()
+                    batch_loss = loss.item()
+                batch_losses.append(batch_loss)
 
-            if scheduler is not None:
-                scheduler.step()
+            with train_sw:
+                if scheduler is not None:
+                    scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             # ---- validate ----
@@ -337,16 +367,18 @@ class GWNModel(BenchmarkModel):
             batch_losses_val: list[float] = []
             with torch.no_grad():
                 for x_batch, y_batch in val_loader:
-                    x_in = x_batch.permute(0, 3, 2, 1)
-                    out = model(x_in)
-                    out = (
-                        out[..., -1]
-                        .reshape(-1, out_steps, output_dim, num_nodes)
-                        .permute(0, 1, 3, 2)
-                    )
-                    out = scaler.inverse_transform(out)
-                    loss = criterion(out, y_batch)
-                    batch_losses_val.append(loss.item())
+                    with train_sw:
+                        x_in = x_batch.permute(0, 3, 2, 1)
+                        out = model(x_in)
+                        out = (
+                            out[..., -1]
+                            .reshape(-1, out_steps, output_dim, num_nodes)
+                            .permute(0, 1, 3, 2)
+                        )
+                        out = y_scaler.inverse_transform(out)
+                        loss = criterion(out, y_batch)
+                        batch_loss = loss.item()
+                    batch_losses_val.append(batch_loss)
             val_loss = float(np.mean(batch_losses_val))
             val_losses.append(val_loss)
 
@@ -363,6 +395,7 @@ class GWNModel(BenchmarkModel):
         if best_state is not None:
             model.load_state_dict(best_state)
         self._model = model
+        self._train_compute_sec = train_sw.elapsed
 
         return TrainingHistory(train_loss=train_losses, val_loss=val_losses)
 
@@ -372,12 +405,13 @@ class GWNModel(BenchmarkModel):
         adj: np.ndarray | None,
         config: Any,
     ) -> np.ndarray:
-        if self._model is None or self._scaler is None:
+        if self._model is None or self._scaler is None or self._y_scaler is None:
             raise RuntimeError("Call fit() before predict().")
 
         cfg = _resolve_config(config)
         device = self._device
         scaler = self._scaler
+        y_scaler = self._y_scaler
         model = self._model
         out_steps = self._out_steps
         output_dim = self._output_dim
@@ -391,23 +425,33 @@ class GWNModel(BenchmarkModel):
             shuffle=False,
         )
 
+        infer_sw = Stopwatch()
         model.eval()
         preds: list[np.ndarray] = []
         with torch.no_grad():
             for (x_batch,) in loader:
-                x_in = x_batch.permute(0, 3, 2, 1)
-                out = model(x_in)
-                out = (
-                    out[..., -1]
-                    .reshape(-1, out_steps, output_dim, num_nodes)
-                    .permute(0, 1, 3, 2)
-                )
-                out = scaler.inverse_transform(out)
-                preds.append(out.cpu().numpy())
+                with infer_sw:
+                    x_in = x_batch.permute(0, 3, 2, 1)
+                    out = model(x_in)
+                    out = (
+                        out[..., -1]
+                        .reshape(-1, out_steps, output_dim, num_nodes)
+                        .permute(0, 1, 3, 2)
+                    )
+                    out = y_scaler.inverse_transform(out)
+                    out_cpu = out.cpu().numpy()
+                preds.append(out_cpu)
 
+        self._infer_compute_sec = infer_sw.elapsed
         return np.concatenate(preds, axis=0)
 
     def get_config(self) -> dict:
         if self._cfg is None:
             return {}
         return asdict(self._cfg)
+
+    def get_train_compute_sec(self) -> float | None:
+        return self._train_compute_sec or None
+
+    def get_inference_compute_sec(self) -> float | None:
+        return self._infer_compute_sec or None

--- a/models/gwn.py
+++ b/models/gwn.py
@@ -31,6 +31,7 @@ from gnn_benchmark.models.GWN.util import (
     calculate_scaled_laplacian,
     sym_adj,
 )
+from gnn_benchmark.utils.losses import masked_huber_loss
 
 
 # ---------------------------------------------------------------------------
@@ -66,10 +67,10 @@ class GWNConfig:
     addaptadj: bool = True
     adjtype: str = "doubletransition"
 
-    # LR scheduler (cosine annealing)
-    use_lr_scheduler: bool = False
-    lr_t_max: int = 100
-    lr_eta_min: float = 1e-5
+    # LR scheduler (multi-step decay — unified across all benchmark models)
+    use_lr_scheduler: bool = True
+    lr_milestones: list[int] = field(default_factory=lambda: [20, 40, 60, 80])
+    lr_decay_ratio: float = 0.5
 
     # Runtime
     seed: int | None = None
@@ -242,9 +243,9 @@ class GWNModel(BenchmarkModel):
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
         x_val_n = torch.nan_to_num(scaler.transform(x_val.to(device)))
 
-        # -- Prepare y (replace NaN with 0 for loss) -----------------------
-        y_train_d = torch.nan_to_num(y_train.to(device))
-        y_val_d = torch.nan_to_num(y_val.to(device))
+        # -- Targets keep NaN so masked_huber_loss can ignore them ---------
+        y_train_d = y_train.to(device)
+        y_val_d = y_val.to(device)
 
         # -- Build graph supports ------------------------------------------
         supports, aptinit = _build_supports(adj, cfg.adjtype, device)
@@ -282,14 +283,16 @@ class GWNModel(BenchmarkModel):
         ).to(device)
 
         # -- Training setup ------------------------------------------------
-        criterion = nn.HuberLoss()
+        criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
             model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
         )
         scheduler = None
         if cfg.use_lr_scheduler:
-            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-                optimizer, T_max=cfg.lr_t_max, eta_min=cfg.lr_eta_min,
+            scheduler = torch.optim.lr_scheduler.MultiStepLR(
+                optimizer,
+                milestones=cfg.lr_milestones,
+                gamma=cfg.lr_decay_ratio,
             )
 
         # -- Training loop -------------------------------------------------

--- a/models/mtgnn.py
+++ b/models/mtgnn.py
@@ -26,6 +26,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.MTGNN.net import gtnet
+from gnn_benchmark.utils.losses import masked_huber_loss
 
 
 # ---------------------------------------------------------------------------
@@ -66,10 +67,10 @@ class MTGNNConfig:
     tanhalpha: float = 3.0
     layer_norm_affline: bool = True
 
-    # LR scheduler (cosine annealing)
-    use_lr_scheduler: bool = False
-    lr_t_max: int = 100
-    lr_eta_min: float = 1e-5
+    # LR scheduler (multi-step decay — unified across all benchmark models)
+    use_lr_scheduler: bool = True
+    lr_milestones: list[int] = field(default_factory=lambda: [20, 40, 60, 80])
+    lr_decay_ratio: float = 0.5
 
     # Runtime
     seed: int | None = None
@@ -198,9 +199,9 @@ class MTGNNModel(BenchmarkModel):
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
         x_val_n = torch.nan_to_num(scaler.transform(x_val.to(device)))
 
-        # -- Prepare y (replace NaN with 0 for loss) -----------------------
-        y_train_d = torch.nan_to_num(y_train.to(device))
-        y_val_d = torch.nan_to_num(y_val.to(device))
+        # -- Targets keep NaN so masked_huber_loss can ignore them ---------
+        y_train_d = y_train.to(device)
+        y_val_d = y_val.to(device)
 
         # -- DataLoaders ---------------------------------------------------
         train_loader = DataLoader(
@@ -241,14 +242,16 @@ class MTGNNModel(BenchmarkModel):
         ).to(device)
 
         # -- Training setup ------------------------------------------------
-        criterion = nn.HuberLoss()
+        criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
             model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
         )
         scheduler = None
         if cfg.use_lr_scheduler:
-            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-                optimizer, T_max=cfg.lr_t_max, eta_min=cfg.lr_eta_min,
+            scheduler = torch.optim.lr_scheduler.MultiStepLR(
+                optimizer,
+                milestones=cfg.lr_milestones,
+                gamma=cfg.lr_decay_ratio,
             )
 
         # -- Training loop -------------------------------------------------

--- a/models/mtgnn.py
+++ b/models/mtgnn.py
@@ -27,6 +27,20 @@ from torch.utils.data import DataLoader, TensorDataset
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.MTGNN.net import gtnet
 from gnn_benchmark.utils.losses import masked_huber_loss
+from gnn_benchmark.utils.timing import Stopwatch
+
+
+def _fit_feature_scaler(
+    tensor: torch.Tensor, feature_dim: int, device: torch.device
+) -> "_FeatureScaler":
+    """NaN-aware per-feature z-score scaler fit (used for both x and y)."""
+    flat = tensor.reshape(-1, feature_dim)
+    mean = torch.nanmean(flat, dim=0)
+    diff_sq = (flat - mean) ** 2
+    count = (~torch.isnan(flat)).sum(dim=0).float()
+    std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
+    std = torch.clamp(std, min=1e-8)
+    return _FeatureScaler(mean, std).to(device)
 
 
 # ---------------------------------------------------------------------------
@@ -45,10 +59,11 @@ class MTGNNConfig:
     # Training hyper-parameters
     lr: float = 0.001
     weight_decay: float = 0.0001
+    eps: float = 1e-8                        # Adam epsilon
     batch_size: int = 64
     max_epochs: int = 100
     early_stop: int = 30
-    clip_grad: float = 5.0
+    clip_grad: float | None = 5.0            # gradient-norm clip; None disables
 
     # Architecture (paper defaults for multi-step forecasting)
     gcn_true: bool = True
@@ -147,10 +162,13 @@ class MTGNNModel(BenchmarkModel):
     def __init__(self) -> None:
         self._model: gtnet | None = None
         self._scaler: _FeatureScaler | None = None
+        self._y_scaler: _FeatureScaler | None = None
         self._device: torch.device | None = None
         self._cfg: MTGNNConfig | None = None
         self._out_steps: int | None = None
         self._output_dim: int | None = None
+        self._train_compute_sec: float = 0.0
+        self._infer_compute_sec: float = 0.0
 
     # ---- BenchmarkModel interface ----------------------------------------
 
@@ -185,15 +203,13 @@ class MTGNNModel(BenchmarkModel):
         self._out_steps = out_steps
         self._output_dim = output_dim
 
-        # -- Fit scaler on x_train (per-feature, ignoring NaN) -------------
-        flat = x_train.reshape(-1, input_dim)  # (S*T*N, D)
-        mean = torch.nanmean(flat, dim=0)      # (D,)
-        diff_sq = (flat - mean) ** 2
-        count = (~torch.isnan(flat)).sum(dim=0).float()
-        std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
-        std = torch.clamp(std, min=1e-8)
-        scaler = _FeatureScaler(mean, std).to(device)
+        # -- Fit scalers (per-feature z-score, NaN-aware) ------------------
+        # Separate y-scaler so inverse_transform uses target stats and
+        # never silently relies on "first D_out features are the targets".
+        scaler = _fit_feature_scaler(x_train, input_dim, device)
+        y_scaler = _fit_feature_scaler(y_train, output_dim, device)
         self._scaler = scaler
+        self._y_scaler = y_scaler
 
         # -- Normalize x and handle NaN ------------------------------------
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
@@ -225,7 +241,11 @@ class MTGNNModel(BenchmarkModel):
             predefined_A=None,
             static_feat=None,
             dropout=cfg.dropout,
-            subgraph_size=min(cfg.subgraph_size, num_nodes),
+            # `subgraph_size` is the top-k neighbours per node inside MTGNN's
+            # graph constructor, so it cannot exceed `num_nodes - 1`
+            # (a node's top-k must exclude itself). Tune this hyperparameter
+            # per dataset — 20 is the paper default for ~200-node graphs.
+            subgraph_size=min(cfg.subgraph_size, max(num_nodes - 1, 1)),
             node_dim=cfg.node_dim,
             dilation_exponential=cfg.dilation_exponential,
             conv_channels=cfg.conv_channels,
@@ -244,7 +264,10 @@ class MTGNNModel(BenchmarkModel):
         # -- Training setup ------------------------------------------------
         criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
-            model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
+            model.parameters(),
+            lr=cfg.lr,
+            weight_decay=cfg.weight_decay,
+            eps=cfg.eps,
         )
         scheduler = None
         if cfg.use_lr_scheduler:
@@ -255,6 +278,7 @@ class MTGNNModel(BenchmarkModel):
             )
 
         # -- Training loop -------------------------------------------------
+        train_sw = Stopwatch()
         train_losses: list[float] = []
         val_losses: list[float] = []
         best_val_loss = float("inf")
@@ -266,26 +290,29 @@ class MTGNNModel(BenchmarkModel):
             model.train()
             batch_losses: list[float] = []
             for x_batch, y_batch in train_loader:
-                # x_batch: (B, T, N, D) -> (B, D, N, T) for gtnet
-                x_in = x_batch.permute(0, 3, 2, 1)
-                out = model(x_in)  # (B, out_steps*output_dim, N, 1)
-                out = (
-                    out.squeeze(-1)
-                    .reshape(-1, out_steps, output_dim, num_nodes)
-                    .permute(0, 1, 3, 2)
-                )  # (B, out_steps, N, output_dim)
-                out = scaler.inverse_transform(out)
-                loss = criterion(out, y_batch)
+                with train_sw:
+                    # x_batch: (B, T, N, D) -> (B, D, N, T) for gtnet
+                    x_in = x_batch.permute(0, 3, 2, 1)
+                    out = model(x_in)  # (B, out_steps*output_dim, N, 1)
+                    out = (
+                        out.squeeze(-1)
+                        .reshape(-1, out_steps, output_dim, num_nodes)
+                        .permute(0, 1, 3, 2)
+                    )  # (B, out_steps, N, output_dim)
+                    out = y_scaler.inverse_transform(out)
+                    loss = criterion(out, y_batch)
 
-                optimizer.zero_grad()
-                loss.backward()
-                if cfg.clip_grad:
-                    nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
-                optimizer.step()
-                batch_losses.append(loss.item())
+                    optimizer.zero_grad()
+                    loss.backward()
+                    if cfg.clip_grad:
+                        nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
+                    optimizer.step()
+                    batch_loss = loss.item()
+                batch_losses.append(batch_loss)
 
-            if scheduler is not None:
-                scheduler.step()
+            with train_sw:
+                if scheduler is not None:
+                    scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             # ---- validate ----
@@ -293,16 +320,18 @@ class MTGNNModel(BenchmarkModel):
             batch_losses_val: list[float] = []
             with torch.no_grad():
                 for x_batch, y_batch in val_loader:
-                    x_in = x_batch.permute(0, 3, 2, 1)
-                    out = model(x_in)
-                    out = (
-                        out.squeeze(-1)
-                        .reshape(-1, out_steps, output_dim, num_nodes)
-                        .permute(0, 1, 3, 2)
-                    )
-                    out = scaler.inverse_transform(out)
-                    loss = criterion(out, y_batch)
-                    batch_losses_val.append(loss.item())
+                    with train_sw:
+                        x_in = x_batch.permute(0, 3, 2, 1)
+                        out = model(x_in)
+                        out = (
+                            out.squeeze(-1)
+                            .reshape(-1, out_steps, output_dim, num_nodes)
+                            .permute(0, 1, 3, 2)
+                        )
+                        out = y_scaler.inverse_transform(out)
+                        loss = criterion(out, y_batch)
+                        batch_loss = loss.item()
+                    batch_losses_val.append(batch_loss)
             val_loss = float(np.mean(batch_losses_val))
             val_losses.append(val_loss)
 
@@ -319,6 +348,7 @@ class MTGNNModel(BenchmarkModel):
         if best_state is not None:
             model.load_state_dict(best_state)
         self._model = model
+        self._train_compute_sec = train_sw.elapsed
 
         return TrainingHistory(train_loss=train_losses, val_loss=val_losses)
 
@@ -328,12 +358,13 @@ class MTGNNModel(BenchmarkModel):
         adj: np.ndarray | None,
         config: Any,
     ) -> np.ndarray:
-        if self._model is None or self._scaler is None:
+        if self._model is None or self._scaler is None or self._y_scaler is None:
             raise RuntimeError("Call fit() before predict().")
 
         cfg = _resolve_config(config)
         device = self._device
         scaler = self._scaler
+        y_scaler = self._y_scaler
         model = self._model
         out_steps = self._out_steps
         output_dim = self._output_dim
@@ -347,23 +378,33 @@ class MTGNNModel(BenchmarkModel):
             shuffle=False,
         )
 
+        infer_sw = Stopwatch()
         model.eval()
         preds: list[np.ndarray] = []
         with torch.no_grad():
             for (x_batch,) in loader:
-                x_in = x_batch.permute(0, 3, 2, 1)
-                out = model(x_in)
-                out = (
-                    out.squeeze(-1)
-                    .reshape(-1, out_steps, output_dim, num_nodes)
-                    .permute(0, 1, 3, 2)
-                )
-                out = scaler.inverse_transform(out)
-                preds.append(out.cpu().numpy())
+                with infer_sw:
+                    x_in = x_batch.permute(0, 3, 2, 1)
+                    out = model(x_in)
+                    out = (
+                        out.squeeze(-1)
+                        .reshape(-1, out_steps, output_dim, num_nodes)
+                        .permute(0, 1, 3, 2)
+                    )
+                    out = y_scaler.inverse_transform(out)
+                    out_cpu = out.cpu().numpy()
+                preds.append(out_cpu)
 
+        self._infer_compute_sec = infer_sw.elapsed
         return np.concatenate(preds, axis=0)
 
     def get_config(self) -> dict:
         if self._cfg is None:
             return {}
         return asdict(self._cfg)
+
+    def get_train_compute_sec(self) -> float | None:
+        return self._train_compute_sec or None
+
+    def get_inference_compute_sec(self) -> float | None:
+        return self._infer_compute_sec or None

--- a/models/mtgode.py
+++ b/models/mtgode.py
@@ -19,7 +19,7 @@ with ``pip install torchdiffeq``.
 from __future__ import annotations
 
 import copy
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 import numpy as np
@@ -29,6 +29,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.MTGODE.model import MTGODE
+from gnn_benchmark.utils.losses import masked_huber_loss
 
 
 # ---------------------------------------------------------------------------
@@ -80,10 +81,10 @@ class MTGODEConfig:
     adjoint: bool = False
     perturb: bool = False
 
-    # LR scheduler (multi-step decay)
+    # LR scheduler (multi-step decay — unified across all benchmark models)
     use_lr_scheduler: bool = True
-    lr_decay_steps: int = 100
-    lr_decay_rate: float = 0.1
+    lr_milestones: list[int] = field(default_factory=lambda: [20, 40, 60, 80])
+    lr_decay_ratio: float = 0.5
 
     # Runtime
     seed: int | None = None
@@ -211,9 +212,9 @@ class MTGODEModel(BenchmarkModel):
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
         x_val_n = torch.nan_to_num(scaler.transform(x_val.to(device)))
 
-        # -- Prepare y (replace NaN with 0 for loss) -----------------------
-        y_train_d = torch.nan_to_num(y_train.to(device))
-        y_val_d = torch.nan_to_num(y_val.to(device))
+        # -- Targets keep NaN so masked_huber_loss can ignore them ---------
+        y_train_d = y_train.to(device)
+        y_val_d = y_val.to(device)
 
         # -- DataLoaders ---------------------------------------------------
         train_loader = DataLoader(
@@ -259,7 +260,7 @@ class MTGODEModel(BenchmarkModel):
         ).to(device)
 
         # -- Training setup ------------------------------------------------
-        criterion = nn.HuberLoss()
+        criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
             model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
         )
@@ -267,8 +268,8 @@ class MTGODEModel(BenchmarkModel):
         if cfg.use_lr_scheduler:
             scheduler = torch.optim.lr_scheduler.MultiStepLR(
                 optimizer,
-                milestones=[cfg.lr_decay_steps],
-                gamma=cfg.lr_decay_rate,
+                milestones=cfg.lr_milestones,
+                gamma=cfg.lr_decay_ratio,
             )
 
         # -- Training loop -------------------------------------------------

--- a/models/mtgode.py
+++ b/models/mtgode.py
@@ -30,6 +30,20 @@ from torch.utils.data import DataLoader, TensorDataset
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.MTGODE.model import MTGODE
 from gnn_benchmark.utils.losses import masked_huber_loss
+from gnn_benchmark.utils.timing import Stopwatch
+
+
+def _fit_feature_scaler(
+    tensor: torch.Tensor, feature_dim: int, device: torch.device
+) -> "_FeatureScaler":
+    """NaN-aware per-feature z-score scaler fit (used for both x and y)."""
+    flat = tensor.reshape(-1, feature_dim)
+    mean = torch.nanmean(flat, dim=0)
+    diff_sq = (flat - mean) ** 2
+    count = (~torch.isnan(flat)).sum(dim=0).float()
+    std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
+    std = torch.clamp(std, min=1e-8)
+    return _FeatureScaler(mean, std).to(device)
 
 
 # ---------------------------------------------------------------------------
@@ -48,10 +62,11 @@ class MTGODEConfig:
     # Training hyper-parameters
     lr: float = 0.001
     weight_decay: float = 0.0001
+    eps: float = 1e-8                        # Adam epsilon
     batch_size: int = 64
     max_epochs: int = 100
     early_stop: int = 30
-    clip_grad: float = 5.0
+    clip_grad: float | None = 5.0            # gradient-norm clip; None disables
 
     # Architecture (paper defaults for METR-LA multi-step forecasting)
     buildA_true: bool = True
@@ -160,10 +175,13 @@ class MTGODEModel(BenchmarkModel):
     def __init__(self) -> None:
         self._model: MTGODE | None = None
         self._scaler: _FeatureScaler | None = None
+        self._y_scaler: _FeatureScaler | None = None
         self._device: torch.device | None = None
         self._cfg: MTGODEConfig | None = None
         self._out_steps: int | None = None
         self._output_dim: int | None = None
+        self._train_compute_sec: float = 0.0
+        self._infer_compute_sec: float = 0.0
 
     # ---- BenchmarkModel interface ----------------------------------------
 
@@ -198,15 +216,13 @@ class MTGODEModel(BenchmarkModel):
         self._out_steps = out_steps
         self._output_dim = output_dim
 
-        # -- Fit scaler on x_train (per-feature, ignoring NaN) -------------
-        flat = x_train.reshape(-1, input_dim)  # (S*T*N, D)
-        mean = torch.nanmean(flat, dim=0)      # (D,)
-        diff_sq = (flat - mean) ** 2
-        count = (~torch.isnan(flat)).sum(dim=0).float()
-        std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
-        std = torch.clamp(std, min=1e-8)
-        scaler = _FeatureScaler(mean, std).to(device)
+        # -- Fit scalers (per-feature z-score, NaN-aware) ------------------
+        # Separate y-scaler so inverse_transform uses target stats and
+        # never silently relies on "first D_out features are the targets".
+        scaler = _fit_feature_scaler(x_train, input_dim, device)
+        y_scaler = _fit_feature_scaler(y_train, output_dim, device)
         self._scaler = scaler
+        self._y_scaler = y_scaler
 
         # -- Normalize x and handle NaN ------------------------------------
         x_train_n = torch.nan_to_num(scaler.transform(x_train.to(device)))
@@ -236,7 +252,11 @@ class MTGODEModel(BenchmarkModel):
             predefined_A=None,
             static_feat=None,
             dropout=cfg.dropout,
-            subgraph_size=min(cfg.subgraph_size, num_nodes),
+            # `subgraph_size` is the top-k neighbours per node inside MTGODE's
+            # graph constructor, so it cannot exceed `num_nodes - 1`
+            # (a node's top-k must exclude itself). Tune this hyperparameter
+            # per dataset — 20 is the paper default for ~200-node graphs.
+            subgraph_size=min(cfg.subgraph_size, max(num_nodes - 1, 1)),
             node_dim=cfg.node_dim,
             dilation_exponential=cfg.dilation_exponential,
             conv_channels=cfg.conv_channels,
@@ -262,7 +282,10 @@ class MTGODEModel(BenchmarkModel):
         # -- Training setup ------------------------------------------------
         criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
-            model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
+            model.parameters(),
+            lr=cfg.lr,
+            weight_decay=cfg.weight_decay,
+            eps=cfg.eps,
         )
         scheduler = None
         if cfg.use_lr_scheduler:
@@ -273,6 +296,7 @@ class MTGODEModel(BenchmarkModel):
             )
 
         # -- Training loop -------------------------------------------------
+        train_sw = Stopwatch()
         train_losses: list[float] = []
         val_losses: list[float] = []
         best_val_loss = float("inf")
@@ -284,27 +308,30 @@ class MTGODEModel(BenchmarkModel):
             model.train()
             batch_losses: list[float] = []
             for x_batch, y_batch in train_loader:
-                # x_batch: (B, T, N, D) -> (B, D, N, T) for MTGODE
-                x_in = x_batch.permute(0, 3, 2, 1)
-                out = model(x_in)  # (B, out_steps*output_dim, N, 1)
-                model.reset_nfe()
-                out = (
-                    out.squeeze(-1)
-                    .reshape(-1, out_steps, output_dim, num_nodes)
-                    .permute(0, 1, 3, 2)
-                )  # (B, out_steps, N, output_dim)
-                out = scaler.inverse_transform(out)
-                loss = criterion(out, y_batch)
+                with train_sw:
+                    # x_batch: (B, T, N, D) -> (B, D, N, T) for MTGODE
+                    x_in = x_batch.permute(0, 3, 2, 1)
+                    out = model(x_in)  # (B, out_steps*output_dim, N, 1)
+                    model.reset_nfe()
+                    out = (
+                        out.squeeze(-1)
+                        .reshape(-1, out_steps, output_dim, num_nodes)
+                        .permute(0, 1, 3, 2)
+                    )  # (B, out_steps, N, output_dim)
+                    out = y_scaler.inverse_transform(out)
+                    loss = criterion(out, y_batch)
 
-                optimizer.zero_grad()
-                loss.backward()
-                if cfg.clip_grad:
-                    nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
-                optimizer.step()
-                batch_losses.append(loss.item())
+                    optimizer.zero_grad()
+                    loss.backward()
+                    if cfg.clip_grad:
+                        nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
+                    optimizer.step()
+                    batch_loss = loss.item()
+                batch_losses.append(batch_loss)
 
-            if scheduler is not None:
-                scheduler.step()
+            with train_sw:
+                if scheduler is not None:
+                    scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             # ---- validate ----
@@ -312,17 +339,19 @@ class MTGODEModel(BenchmarkModel):
             batch_losses_val: list[float] = []
             with torch.no_grad():
                 for x_batch, y_batch in val_loader:
-                    x_in = x_batch.permute(0, 3, 2, 1)
-                    out = model(x_in)
-                    model.reset_nfe()
-                    out = (
-                        out.squeeze(-1)
-                        .reshape(-1, out_steps, output_dim, num_nodes)
-                        .permute(0, 1, 3, 2)
-                    )
-                    out = scaler.inverse_transform(out)
-                    loss = criterion(out, y_batch)
-                    batch_losses_val.append(loss.item())
+                    with train_sw:
+                        x_in = x_batch.permute(0, 3, 2, 1)
+                        out = model(x_in)
+                        model.reset_nfe()
+                        out = (
+                            out.squeeze(-1)
+                            .reshape(-1, out_steps, output_dim, num_nodes)
+                            .permute(0, 1, 3, 2)
+                        )
+                        out = y_scaler.inverse_transform(out)
+                        loss = criterion(out, y_batch)
+                        batch_loss = loss.item()
+                    batch_losses_val.append(batch_loss)
             val_loss = float(np.mean(batch_losses_val))
             val_losses.append(val_loss)
 
@@ -339,6 +368,7 @@ class MTGODEModel(BenchmarkModel):
         if best_state is not None:
             model.load_state_dict(best_state)
         self._model = model
+        self._train_compute_sec = train_sw.elapsed
 
         return TrainingHistory(train_loss=train_losses, val_loss=val_losses)
 
@@ -348,12 +378,13 @@ class MTGODEModel(BenchmarkModel):
         adj: np.ndarray | None,
         config: Any,
     ) -> np.ndarray:
-        if self._model is None or self._scaler is None:
+        if self._model is None or self._scaler is None or self._y_scaler is None:
             raise RuntimeError("Call fit() before predict().")
 
         cfg = _resolve_config(config)
         device = self._device
         scaler = self._scaler
+        y_scaler = self._y_scaler
         model = self._model
         out_steps = self._out_steps
         output_dim = self._output_dim
@@ -367,24 +398,34 @@ class MTGODEModel(BenchmarkModel):
             shuffle=False,
         )
 
+        infer_sw = Stopwatch()
         model.eval()
         preds: list[np.ndarray] = []
         with torch.no_grad():
             for (x_batch,) in loader:
-                x_in = x_batch.permute(0, 3, 2, 1)
-                out = model(x_in)
-                model.reset_nfe()
-                out = (
-                    out.squeeze(-1)
-                    .reshape(-1, out_steps, output_dim, num_nodes)
-                    .permute(0, 1, 3, 2)
-                )
-                out = scaler.inverse_transform(out)
-                preds.append(out.cpu().numpy())
+                with infer_sw:
+                    x_in = x_batch.permute(0, 3, 2, 1)
+                    out = model(x_in)
+                    model.reset_nfe()
+                    out = (
+                        out.squeeze(-1)
+                        .reshape(-1, out_steps, output_dim, num_nodes)
+                        .permute(0, 1, 3, 2)
+                    )
+                    out = y_scaler.inverse_transform(out)
+                    out_cpu = out.cpu().numpy()
+                preds.append(out_cpu)
 
+        self._infer_compute_sec = infer_sw.elapsed
         return np.concatenate(preds, axis=0)
 
     def get_config(self) -> dict:
         if self._cfg is None:
             return {}
         return asdict(self._cfg)
+
+    def get_train_compute_sec(self) -> float | None:
+        return self._train_compute_sec or None
+
+    def get_inference_compute_sec(self) -> float | None:
+        return self._infer_compute_sec or None

--- a/models/staeformer.py
+++ b/models/staeformer.py
@@ -24,6 +24,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.STAEFormer.model.STAEformer import STAEformer
+from gnn_benchmark.utils.losses import masked_huber_loss
 
 
 # ---------------------------------------------------------------------------
@@ -42,12 +43,15 @@ class STAEFormerConfig:
     # Training hyper-parameters
     lr: float = 0.001
     weight_decay: float = 0.0003
-    milestones: list[int] = field(default_factory=lambda: [20, 30])
-    lr_decay_rate: float = 0.1
     batch_size: int = 16
     max_epochs: int = 200
     early_stop: int = 30
     clip_grad: float | None = None
+
+    # LR scheduler (multi-step decay — unified across all benchmark models)
+    use_lr_scheduler: bool = True
+    lr_milestones: list[int] = field(default_factory=lambda: [20, 30])
+    lr_decay_ratio: float = 0.1
 
     # Architecture (paper defaults — override only if experimenting)
     input_embedding_dim: int = 24
@@ -221,13 +225,17 @@ class STAEFormerModel(BenchmarkModel):
         ).to(device)
 
         # -- Training setup ------------------------------------------------
-        criterion = nn.HuberLoss()
+        criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
             model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
         )
-        scheduler = torch.optim.lr_scheduler.MultiStepLR(
-            optimizer, milestones=cfg.milestones, gamma=cfg.lr_decay_rate,
-        )
+        scheduler = None
+        if cfg.use_lr_scheduler:
+            scheduler = torch.optim.lr_scheduler.MultiStepLR(
+                optimizer,
+                milestones=cfg.lr_milestones,
+                gamma=cfg.lr_decay_ratio,
+            )
 
         # -- Training loop -------------------------------------------------
         train_losses: list[float] = []
@@ -255,7 +263,8 @@ class STAEFormerModel(BenchmarkModel):
                 optimizer.step()
                 batch_losses.append(loss.item())
 
-            scheduler.step()
+            if scheduler is not None:
+                scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             # ---- validate ----
@@ -357,5 +366,5 @@ class STAEFormerModel(BenchmarkModel):
         x_batch = x_batch.to(device, non_blocking=non_blocking)
         y_batch = y_batch.to(device, non_blocking=non_blocking)
         x_batch = torch.nan_to_num(scaler.transform(x_batch))
-        y_batch = torch.nan_to_num(y_batch)
+        # Targets keep NaN so masked_huber_loss can ignore missing positions.
         return x_batch, y_batch

--- a/models/staeformer.py
+++ b/models/staeformer.py
@@ -25,6 +25,20 @@ from torch.utils.data import DataLoader, TensorDataset
 from gnn_benchmark.models.base import BenchmarkModel, TrainingHistory
 from gnn_benchmark.models.STAEFormer.model.STAEformer import STAEformer
 from gnn_benchmark.utils.losses import masked_huber_loss
+from gnn_benchmark.utils.timing import Stopwatch
+
+
+def _fit_feature_scaler(
+    tensor: torch.Tensor, feature_dim: int, device: torch.device
+) -> "_FeatureScaler":
+    """NaN-aware per-feature z-score scaler fit (used for both x and y)."""
+    flat = tensor.reshape(-1, feature_dim)
+    mean = torch.nanmean(flat, dim=0)
+    diff_sq = (flat - mean) ** 2
+    count = (~torch.isnan(flat)).sum(dim=0).float()
+    std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
+    std = torch.clamp(std, min=1e-8)
+    return _FeatureScaler(mean, std).to(device)
 
 
 # ---------------------------------------------------------------------------
@@ -43,10 +57,11 @@ class STAEFormerConfig:
     # Training hyper-parameters
     lr: float = 0.001
     weight_decay: float = 0.0003
+    eps: float = 1e-8                        # Adam epsilon
     batch_size: int = 16
     max_epochs: int = 200
     early_stop: int = 30
-    clip_grad: float | None = None
+    clip_grad: float | None = 5.0            # gradient-norm clip; None disables
 
     # LR scheduler (multi-step decay — unified across all benchmark models)
     use_lr_scheduler: bool = True
@@ -60,6 +75,15 @@ class STAEFormerConfig:
     num_heads: int = 4
     num_layers: int = 3
     dropout: float = 0.1
+
+    # Time-of-day embedding. ``steps_per_day`` is the number of input
+    # timesteps per 24h period (288 for 5-min cadence, 24 for hourly,
+    # 96 for 15-min, 1 for daily). It only matters when
+    # ``tod_embedding_dim > 0``; the default keeps the embedding off
+    # because the harness does not provide a TOD feature column. Set
+    # both fields explicitly when wiring up TOD inputs by hand.
+    steps_per_day: int = 288
+    tod_embedding_dim: int = 0
 
     # Runtime
     seed: int | None = None
@@ -135,10 +159,13 @@ class STAEFormerModel(BenchmarkModel):
     def __init__(self) -> None:
         self._model: STAEformer | None = None
         self._scaler: _FeatureScaler | None = None
+        self._y_scaler: _FeatureScaler | None = None
         self._device: torch.device | None = None
         self._cfg: STAEFormerConfig | None = None
         self._out_steps: int | None = None
         self._output_dim: int | None = None
+        self._train_compute_sec: float = 0.0
+        self._infer_compute_sec: float = 0.0
 
     # ---- BenchmarkModel interface ----------------------------------------
 
@@ -173,18 +200,13 @@ class STAEFormerModel(BenchmarkModel):
         self._out_steps = out_steps
         self._output_dim = output_dim
 
-        # -- Fit scaler on x_train (per-feature, ignoring NaN) -------------
-        # Computed on CPU so we do not have to stage the full split on GPU.
-        # x_train: (S, T, N, D)
-        flat = x_train.reshape(-1, input_dim)  # (S*T*N, D)
-        mean = torch.nanmean(flat, dim=0)      # (D,)
-        # nanstd: manual since torch has no nanstd
-        diff_sq = (flat - mean) ** 2
-        count = (~torch.isnan(flat)).sum(dim=0).float()
-        std = torch.sqrt(torch.nansum(diff_sq, dim=0) / count)
-        std = torch.clamp(std, min=1e-8)
-        scaler = _FeatureScaler(mean, std).to(device)
+        # -- Fit scalers (per-feature z-score, NaN-aware) ------------------
+        # Separate y-scaler so inverse_transform uses target stats and
+        # never silently relies on "first D_out features are the targets".
+        scaler = _fit_feature_scaler(x_train, input_dim, device)
+        y_scaler = _fit_feature_scaler(y_train, output_dim, device)
         self._scaler = scaler
+        self._y_scaler = y_scaler
 
         # -- DataLoaders (splits stay on CPU; batches stream to device) ---
         # Keeping the raw tensors off GPU is the main memory saving: only
@@ -205,15 +227,19 @@ class STAEFormerModel(BenchmarkModel):
         )
 
         # -- Build model ---------------------------------------------------
+        # ``steps_per_day`` only feeds the time-of-day embedding when
+        # ``tod_embedding_dim > 0``; with the default 0 it is harmless,
+        # but the field is still configurable for users who wire TOD
+        # features into ``input_dim`` themselves.
         model = STAEformer(
             num_nodes=num_nodes,
             in_steps=in_steps,
             out_steps=out_steps,
-            steps_per_day=288,
+            steps_per_day=cfg.steps_per_day,
             input_dim=input_dim,
             output_dim=output_dim,
             input_embedding_dim=cfg.input_embedding_dim,
-            tod_embedding_dim=0,
+            tod_embedding_dim=cfg.tod_embedding_dim,
             dow_embedding_dim=0,
             spatial_embedding_dim=0,
             adaptive_embedding_dim=cfg.adaptive_embedding_dim,
@@ -227,7 +253,10 @@ class STAEFormerModel(BenchmarkModel):
         # -- Training setup ------------------------------------------------
         criterion = masked_huber_loss
         optimizer = torch.optim.Adam(
-            model.parameters(), lr=cfg.lr, weight_decay=cfg.weight_decay,
+            model.parameters(),
+            lr=cfg.lr,
+            weight_decay=cfg.weight_decay,
+            eps=cfg.eps,
         )
         scheduler = None
         if cfg.use_lr_scheduler:
@@ -238,6 +267,7 @@ class STAEFormerModel(BenchmarkModel):
             )
 
         # -- Training loop -------------------------------------------------
+        train_sw = Stopwatch()
         train_losses: list[float] = []
         val_losses: list[float] = []
         best_val_loss = float("inf")
@@ -249,22 +279,26 @@ class STAEFormerModel(BenchmarkModel):
             model.train()
             batch_losses: list[float] = []
             for x_batch, y_batch in train_loader:
+                # Host→device transfer + scaling are excluded from compute.
                 x_batch, y_batch = self._prepare_batch(
                     x_batch, y_batch, scaler, device,
                 )
-                out = model(x_batch)
-                out = scaler.inverse_transform(out)
-                loss = criterion(out, y_batch)
+                with train_sw:
+                    out = model(x_batch)
+                    out = y_scaler.inverse_transform(out)
+                    loss = criterion(out, y_batch)
 
-                optimizer.zero_grad()
-                loss.backward()
-                if cfg.clip_grad:
-                    nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
-                optimizer.step()
-                batch_losses.append(loss.item())
+                    optimizer.zero_grad()
+                    loss.backward()
+                    if cfg.clip_grad:
+                        nn.utils.clip_grad_norm_(model.parameters(), cfg.clip_grad)
+                    optimizer.step()
+                    batch_loss = loss.item()
+                batch_losses.append(batch_loss)
 
-            if scheduler is not None:
-                scheduler.step()
+            with train_sw:
+                if scheduler is not None:
+                    scheduler.step()
             train_losses.append(float(np.mean(batch_losses)))
 
             # ---- validate ----
@@ -275,10 +309,12 @@ class STAEFormerModel(BenchmarkModel):
                     x_batch, y_batch = self._prepare_batch(
                         x_batch, y_batch, scaler, device,
                     )
-                    out = model(x_batch)
-                    out = scaler.inverse_transform(out)
-                    loss = criterion(out, y_batch)
-                    batch_losses_val.append(loss.item())
+                    with train_sw:
+                        out = model(x_batch)
+                        out = y_scaler.inverse_transform(out)
+                        loss = criterion(out, y_batch)
+                        batch_loss = loss.item()
+                    batch_losses_val.append(batch_loss)
             val_loss = float(np.mean(batch_losses_val))
             val_losses.append(val_loss)
 
@@ -300,6 +336,7 @@ class STAEFormerModel(BenchmarkModel):
         if best_state is not None:
             model.load_state_dict(best_state)
         self._model = model
+        self._train_compute_sec = train_sw.elapsed
 
         if device.type == "cuda":
             torch.cuda.empty_cache()
@@ -312,12 +349,13 @@ class STAEFormerModel(BenchmarkModel):
         adj: np.ndarray | None,
         config: Any,
     ) -> np.ndarray:
-        if self._model is None or self._scaler is None:
+        if self._model is None or self._scaler is None or self._y_scaler is None:
             raise RuntimeError("Call fit() before predict().")
 
         cfg = _resolve_config(config)
         device = self._device
         scaler = self._scaler
+        y_scaler = self._y_scaler
         model = self._model
 
         pin = device.type == "cuda"
@@ -328,16 +366,20 @@ class STAEFormerModel(BenchmarkModel):
             pin_memory=pin,
         )
 
+        infer_sw = Stopwatch()
         model.eval()
         preds: list[np.ndarray] = []
         with torch.no_grad():
             for (x_batch,) in loader:
                 x_batch = x_batch.to(device, non_blocking=pin)
                 x_batch = torch.nan_to_num(scaler.transform(x_batch))
-                out = model(x_batch)
-                out = scaler.inverse_transform(out)
-                preds.append(out.cpu().numpy())
+                with infer_sw:
+                    out = model(x_batch)
+                    out = y_scaler.inverse_transform(out)
+                    out_cpu = out.cpu().numpy()
+                preds.append(out_cpu)
 
+        self._infer_compute_sec = infer_sw.elapsed
         if device.type == "cuda":
             torch.cuda.empty_cache()
 
@@ -347,6 +389,12 @@ class STAEFormerModel(BenchmarkModel):
         if self._cfg is None:
             return {}
         return asdict(self._cfg)
+
+    def get_train_compute_sec(self) -> float | None:
+        return self._train_compute_sec or None
+
+    def get_inference_compute_sec(self) -> float | None:
+        return self._infer_compute_sec or None
 
     # ---- Private helpers -------------------------------------------------
 

--- a/tuning/tuner.py
+++ b/tuning/tuner.py
@@ -64,6 +64,7 @@ from gnn_benchmark.benchmark import BenchmarkRunner, PreparedDataset
 from gnn_benchmark.core.workspace import DataWorkspace
 from gnn_benchmark.models import BenchmarkModel, TrainingHistory
 from gnn_benchmark.tuning.search_space import Sampler
+from gnn_benchmark.utils.timing import ComputeTimer
 
 try:
     import torch
@@ -101,6 +102,11 @@ class TrialResult:
     ``config`` is the full config passed to ``fit`` (base + overrides).
     ``overrides`` records only the fields the tuner varied, so results are
     easy to read in the summary table.
+
+    ``duration_sec`` is total wall-clock; ``compute_time_sec`` is the
+    pure-compute portion spent inside ``model.fit``, isolated so models
+    with heavy graph construction or long DataLoader stalls can be
+    compared on the actual training-step budget.
     """
 
     trial_index: int
@@ -109,6 +115,7 @@ class TrialResult:
     best_val_loss: float | None
     train_history: TrainingHistory | None
     duration_sec: float
+    compute_time_sec: float = 0.0
     error: str | None = None
 
 
@@ -120,6 +127,16 @@ class TuningResult:
     dataset_name: str
     trials: list[TrialResult] = field(default_factory=list)
     best: TrialResult | None = None
+
+    @property
+    def total_compute_time_sec(self) -> float:
+        """Sum of pure-compute fit time across all trials.
+
+        Useful for forwarding to a downstream :class:`BenchmarkResult` so a
+        results report can attribute the hyperparameter-search budget
+        alongside the final training and inference budgets.
+        """
+        return sum(t.compute_time_sec for t in self.trials)
 
     def summary(self) -> str:
         """Return a formatted table of trials and the winning config."""
@@ -160,6 +177,17 @@ class TuningResult:
             lines.append(f"Best: trial {self.best.trial_index}  "
                          f"val_loss={self.best.best_val_loss:.4f}  "
                          f"overrides={self.best.overrides}")
+        # Compute-budget block: separates the "hyperparameter training
+        # step" cost from the final training cost so reports can show
+        # both numbers side by side.
+        compute_total = self.total_compute_time_sec
+        wall_total = sum(t.duration_sec for t in self.trials)
+        if compute_total > 0 or wall_total > 0:
+            lines.append(
+                f"Hyperparameter search compute: "
+                f"{compute_total:.2f}s of compute over "
+                f"{wall_total:.2f}s wall ({len(self.trials)} trial(s))"
+            )
         lines.append(thick)
         return "\n".join(lines)
 
@@ -168,6 +196,7 @@ class TuningResult:
         return {
             "model_name": self.model_name,
             "dataset_name": self.dataset_name,
+            "total_compute_time_sec": self.total_compute_time_sec,
             "trials": [
                 {
                     "trial_index": t.trial_index,
@@ -177,6 +206,7 @@ class TuningResult:
                     "train_loss": t.train_history.train_loss if t.train_history else None,
                     "val_loss": t.train_history.val_loss if t.train_history else None,
                     "duration_sec": t.duration_sec,
+                    "compute_time_sec": t.compute_time_sec,
                     "error": t.error,
                 }
                 for t in self.trials
@@ -319,13 +349,16 @@ class HyperparameterTuner:
             error: str | None = None
 
             model: BenchmarkModel | None = None
+            compute_elapsed = 0.0
             try:
                 model = self.model_factory()
-                history = model.fit(
-                    prepared.x_train, prepared.y_train,
-                    prepared.x_val, prepared.y_val,
-                    prepared.adj, trial_cfg,
-                )
+                with ComputeTimer() as timer:
+                    history = model.fit(
+                        prepared.x_train, prepared.y_train,
+                        prepared.x_val, prepared.y_val,
+                        prepared.adj, trial_cfg,
+                    )
+                compute_elapsed = timer.elapsed
                 if history is None:
                     raise RuntimeError(
                         "model.fit() returned None — the tuner needs a "
@@ -351,6 +384,7 @@ class HyperparameterTuner:
                 best_val_loss=best_val,
                 train_history=history,
                 duration_sec=duration,
+                compute_time_sec=compute_elapsed,
                 error=error,
             )
             result.trials.append(trial)

--- a/tuning/tuner.py
+++ b/tuning/tuner.py
@@ -64,7 +64,7 @@ from gnn_benchmark.benchmark import BenchmarkRunner, PreparedDataset
 from gnn_benchmark.core.workspace import DataWorkspace
 from gnn_benchmark.models import BenchmarkModel, TrainingHistory
 from gnn_benchmark.tuning.search_space import Sampler
-from gnn_benchmark.utils.timing import ComputeTimer
+from gnn_benchmark.utils.timing import WallTimer
 
 try:
     import torch
@@ -352,13 +352,21 @@ class HyperparameterTuner:
             compute_elapsed = 0.0
             try:
                 model = self.model_factory()
-                with ComputeTimer() as timer:
+                with WallTimer() as timer:
                     history = model.fit(
                         prepared.x_train, prepared.y_train,
                         prepared.x_val, prepared.y_val,
                         prepared.adj, trial_cfg,
                     )
-                compute_elapsed = timer.elapsed
+                # Prefer the wrapper's per-batch compute total when it
+                # exposes one (the per-batch Stopwatch excludes
+                # DataLoader iteration and host↔device transfer).  Fall
+                # back to the outer wall-clock so legacy wrappers still
+                # contribute a number.
+                wrapper_compute = model.get_train_compute_sec()
+                compute_elapsed = (
+                    wrapper_compute if wrapper_compute is not None else timer.elapsed
+                )
                 if history is None:
                     raise RuntimeError(
                         "model.fit() returned None — the tuner needs a "

--- a/utils/losses.py
+++ b/utils/losses.py
@@ -1,0 +1,41 @@
+"""Training loss helpers shared across model wrappers.
+
+Every benchmark model wrapper trains with Huber loss, but targets may
+contain NaN to mark missing values (see :class:`BenchmarkModel`'s tensor
+contract).  Replacing those NaNs with 0 — as a naive ``nan_to_num`` does
+— silently treats missingness as a true-zero target, which biases the
+model toward predicting zero everywhere a sensor is offline.  Evaluation
+metrics already mask NaN positions, so the asymmetry distorts both the
+training signal and the train↔val↔test loss comparison.
+
+:func:`masked_huber_loss` instead computes Huber loss only over positions
+where the target is finite, matching how metrics are scored.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def masked_huber_loss(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    delta: float = 1.0,
+) -> torch.Tensor:
+    """Mean Huber loss over positions where ``target`` is finite.
+
+    NaN entries in ``target`` (the benchmark's missing-value sentinel)
+    contribute neither to the sum nor to the denominator, so the model
+    is never penalised for them.  When every position is missing the
+    function returns a zero tensor that still carries gradient through
+    ``pred`` so an autograd graph stays connected.
+    """
+    mask = ~torch.isnan(target)
+    target_safe = torch.where(mask, target, torch.zeros_like(target))
+    elementwise = F.huber_loss(pred, target_safe, reduction="none", delta=delta)
+    elementwise = elementwise * mask.to(elementwise.dtype)
+    n_valid = mask.sum()
+    if n_valid == 0:
+        return pred.sum() * 0.0
+    return elementwise.sum() / n_valid

--- a/utils/timing.py
+++ b/utils/timing.py
@@ -1,0 +1,44 @@
+"""Compute-time measurement helper used by the benchmark harness.
+
+The runner times the actual compute portions of training and inference
+(``model.fit`` and ``model.predict``) so different models can be
+compared on a per-call basis.  When CUDA is in use we synchronise
+before reading the wall clock so kernel-launch lag does not bias the
+measurement.
+"""
+
+from __future__ import annotations
+
+import time
+
+try:
+    import torch
+    _TORCH_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _TORCH_AVAILABLE = False
+
+
+class ComputeTimer:
+    """Context manager that records elapsed compute time in seconds.
+
+    Usage::
+
+        with ComputeTimer() as t:
+            model.fit(...)
+        elapsed = t.elapsed
+    """
+
+    def __init__(self) -> None:
+        self.elapsed: float = 0.0
+        self._start: float = 0.0
+
+    def __enter__(self) -> "ComputeTimer":
+        if _TORCH_AVAILABLE and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        self._start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if _TORCH_AVAILABLE and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        self.elapsed = time.perf_counter() - self._start

--- a/utils/timing.py
+++ b/utils/timing.py
@@ -1,10 +1,21 @@
-"""Compute-time measurement helper used by the benchmark harness.
+"""Wall-clock and compute-time measurement helpers used by the benchmark.
 
-The runner times the actual compute portions of training and inference
-(``model.fit`` and ``model.predict``) so different models can be
-compared on a per-call basis.  When CUDA is in use we synchronise
-before reading the wall clock so kernel-launch lag does not bias the
-measurement.
+Two helpers live here:
+
+* :class:`WallTimer` (alias :class:`ComputeTimer` for backwards compatibility)
+  is a one-shot context manager that records wall-clock seconds spent in the
+  block, syncing CUDA on enter and exit.  The benchmark harness uses it to
+  measure end-to-end ``model.fit`` / ``model.predict`` time.
+
+* :class:`Stopwatch` is an *accumulator* — it can be entered repeatedly and
+  totals the time spent inside it.  Model wrappers use it to time only the
+  pure compute spans (forward + backward + step + criterion + scaler ops),
+  excluding DataLoader iteration, host→device transfers, and best-state
+  CPU clones.  That way the published per-model compute budget is not
+  inflated by data movement that has nothing to do with the model itself.
+
+When CUDA is in use both helpers call ``torch.cuda.synchronize()`` so
+asynchronous kernel launches do not leak into the next measurement.
 """
 
 from __future__ import annotations
@@ -18,12 +29,17 @@ except ImportError:  # pragma: no cover
     _TORCH_AVAILABLE = False
 
 
-class ComputeTimer:
-    """Context manager that records elapsed compute time in seconds.
+def _cuda_sync() -> None:
+    if _TORCH_AVAILABLE and torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+class WallTimer:
+    """One-shot context manager recording elapsed wall-clock seconds.
 
     Usage::
 
-        with ComputeTimer() as t:
+        with WallTimer() as t:
             model.fit(...)
         elapsed = t.elapsed
     """
@@ -32,13 +48,68 @@ class ComputeTimer:
         self.elapsed: float = 0.0
         self._start: float = 0.0
 
-    def __enter__(self) -> "ComputeTimer":
-        if _TORCH_AVAILABLE and torch.cuda.is_available():
-            torch.cuda.synchronize()
+    def __enter__(self) -> "WallTimer":
+        _cuda_sync()
         self._start = time.perf_counter()
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:
-        if _TORCH_AVAILABLE and torch.cuda.is_available():
-            torch.cuda.synchronize()
+        _cuda_sync()
         self.elapsed = time.perf_counter() - self._start
+
+
+# Backwards-compatible alias — older code imports ComputeTimer.
+ComputeTimer = WallTimer
+
+
+class Stopwatch:
+    """Accumulator that totals wall-clock seconds spent inside it.
+
+    Unlike :class:`WallTimer`, a :class:`Stopwatch` is meant to be
+    re-entered many times in a single training loop — once per batch,
+    say — so the cumulative compute span can be reported separately
+    from data-loading and bookkeeping time.  Both the context-manager
+    and ``start()`` / ``stop()`` interfaces are supported::
+
+        sw = Stopwatch()
+        for x_batch, y_batch in loader:
+            x_batch = x_batch.to(device)        # NOT timed
+            with sw:
+                out = model(x_batch)
+                loss = criterion(out, y_batch)
+                loss.backward()
+                optimizer.step()
+        total_compute_sec = sw.elapsed
+
+    The helper is reset by calling :meth:`reset`.  CUDA syncs bracket
+    every entered span so an unfinished kernel from the previous batch
+    does not bleed into the next measurement.
+    """
+
+    def __init__(self) -> None:
+        self.elapsed: float = 0.0
+        self._t0: float | None = None
+
+    def reset(self) -> None:
+        self.elapsed = 0.0
+        self._t0 = None
+
+    def start(self) -> None:
+        if self._t0 is not None:
+            raise RuntimeError("Stopwatch.start() called while already running.")
+        _cuda_sync()
+        self._t0 = time.perf_counter()
+
+    def stop(self) -> None:
+        if self._t0 is None:
+            raise RuntimeError("Stopwatch.stop() called without a matching start().")
+        _cuda_sync()
+        self.elapsed += time.perf_counter() - self._t0
+        self._t0 = None
+
+    def __enter__(self) -> "Stopwatch":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.stop()


### PR DESCRIPTION
## Summary

This PR introduces two major improvements to the benchmark framework:

1. **Compute-time tracking**: Distinguishes pure compute time (forward + backward + step + criterion) from wall-clock time by wrapping training loops with a `Stopwatch` utility. This allows fair cross-model comparison by excluding data-loading overhead and host↔device transfers.

2. **NaN-aware loss function**: Replaces `nn.HuberLoss()` with `masked_huber_loss()` across all model wrappers to properly handle missing values (NaN) in targets. The new loss only computes error over finite positions, preventing the model from being penalized for missing data.

## Key Changes

### New Utilities
- **`utils/timing.py`**: Added `WallTimer` (one-shot context manager) and `Stopwatch` (accumulator) for measuring wall-clock and compute time with CUDA synchronization
- **`utils/losses.py`**: Added `masked_huber_loss()` that computes Huber loss only over finite target positions, matching how evaluation metrics handle NaN

### Model Wrapper Updates (all 8 models: GTS, GWN, MTGODE, MTGNN, STAEFormer, ASTGCN, D2STGNN)
- Extracted scaler fitting into `_fit_feature_scaler()` helper function
- Added separate `_y_scaler` for targets (prevents silent reliance on "first D_out features are targets")
- Replaced `nn.HuberLoss()` with `masked_huber_loss`
- Wrapped training loops with `Stopwatch` to accumulate pure compute time
- Changed target handling: keep NaN instead of replacing with 0 via `nan_to_num`
- Updated LR scheduler configs to use unified multi-step decay across models
- Made `clip_grad` optional (can be `None` to disable)
- Added `eps` parameter to Adam optimizer configs

### Benchmark Harness (`benchmark.py`)
- Extended `DatasetResult` with compute-time fields:
  - `train_compute_sec` / `inference_compute_sec`: Pure compute time from model wrappers
  - `train_wall_sec` / `inference_wall_sec`: Wall-clock time from harness
  - Deprecated `train_time_sec` / `inference_time_sec` properties for backwards compatibility
- Extended `BenchmarkResult` with `tuning_compute_time_sec` to track hyperparameter search budget
- Enhanced summary output to display both compute and wall-clock times per dataset and in aggregate

### Tuning (`tuning/tuner.py`)
- Added `compute_time_sec` field to `TrialResult`
- Added `total_compute_time_sec` property to `TuningResult` for aggregating search budget

### Base Model Interface (`models/base.py`)
- Added `get_train_compute_sec()` and `get_inference_compute_sec()` methods for wrappers to expose pure compute time

## Implementation Details

- **Scaler separation**: Each model now maintains both `_scaler` (for inputs) and `_y_scaler` (for targets), ensuring inverse transforms use the correct statistics
- **NaN handling**: Targets preserve NaN values through the pipeline; only the loss function masks them, keeping the training signal clean
- **Timing precision**: CUDA synchronization brackets all measurements to prevent asynchronous kernel launches from skewing results
- **Backwards compatibility**: Deprecated time fields remain functional via properties, ensuring existing JSON reports and external callers continue working

https://claude.ai/code/session_013gJToB6XiBiFhGG9j4SexA