### PR TITLE
Add per-model hyperparameter search-space factories

### DIFF
--- a/examples_new/_shared.py
+++ b/examples_new/_shared.py
@@ -21,19 +21,25 @@ Earlier examples (now under ``examples_old/``) had a few fairness problems:
     winner outside `{1e-3, 5e-4}`.
   * **Per-dataset memory tweaks were scattered across files** with no single
     source of truth — easy for two examples on the same dataset to drift.
-  * **Search-space *shape* differed across models** (e.g. STAEFormer tuned
-    depth + heads while everyone else tuned width + dropout).
+  * **Identical search-space *shape* across models risked missing knobs
+    that are hugely influential for specific architectures** (e.g. ASTGCN's
+    Chebyshev order ``K``, GWN's ``addaptadj`` toggle, MTGODE's ODE step).
+    Leaving such knobs at a fixed default lets a poor original choice
+    cascade into a bad cross-model result.
 
 Fair protocol used here
 -----------------------
-  * **Random search, n_trials=12, seed=0** for every (model, dataset) pair.
+  * **Random search, n_trials=18, seed=0** for every (model, dataset) pair.
   * **Training schedule depends only on the dataset** (memory budget):
     `batch_size`, `max_epochs`, `early_stop`, and `lr_milestones` are pinned
     in :data:`DATASET_SCHEDULE`, not in any single example.
-  * **Search space has the same shape for every model**: `lr` (LogUniform
-    1e-4..5e-3), one regularization knob (`dropout` where the model has it,
-    `weight_decay` for ASTGCN/GTS which don't), and one capacity axis (the
-    model's principal width parameter).
+  * **Search space is per-model**: every example uses the model's default
+    factory in :mod:`gnn_benchmark.tuning.spaces` — ``lr`` (log-uniform,
+    same range for every model), one shared regularization axis
+    (``dropout`` or ``weight_decay`` depending on what the model exposes),
+    one capacity axis, plus 1-2 model-specific high-impact knobs.
+    Dataset-specific overrides (memory caps) are applied via the
+    factory's ``**overrides``, so each example is one factory call.
   * **`lr` is sampled log-uniform**, the natural distribution for LR search.
 
 Limits we don't claim to solve
@@ -56,7 +62,7 @@ from typing import Any
 # ---------------------------------------------------------------------------
 
 WORKSPACE = "./benchmark_workspace"
-N_TRIALS = 12
+N_TRIALS = 18
 SEED = 0
 STRATEGY = "random"
 

--- a/examples_new/chicago_bikes_astgcn_example.py
+++ b/examples_new/chicago_bikes_astgcn_example.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """ASTGCN on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``nb_chev_filter``.  Reg axis: ``weight_decay``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``nb_chev_filter``
+is capped at 64 for the 515-node graph.
 """
 
 from gnn_benchmark.models import ASTGCNConfig, ASTGCNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, astgcn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +18,9 @@ run_example(
     model_factory=lambda: ASTGCNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":             LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay":   Categorical([0.0, 1e-5, 1e-4]),
-        "nb_chev_filter": Categorical([32, 64]),
-    },
+    search_space=astgcn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        nb_chev_filter=Categorical([32, 64]),
+    ),
 )

--- a/examples_new/chicago_bikes_d2stgnn_example.py
+++ b/examples_new/chicago_bikes_d2stgnn_example.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """D2STGNN on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``num_hidden``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``num_hidden``
+is capped at 32 — D2STGNN holds an N×N dynamic-graph scores tensor per
+layer.
 """
 
 from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, d2stgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +19,9 @@ run_example(
     model_factory=lambda: D2STGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":         LogUniform(LR_LOW, LR_HIGH),
-        "dropout":    Categorical([0.0, 0.1, 0.2]),
-        "num_hidden": Categorical([16, 32]),
-    },
+    search_space=d2stgnn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        num_hidden=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/chicago_bikes_gts_example.py
+++ b/examples_new/chicago_bikes_gts_example.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """GTS on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``rnn_units``.  Reg axis: ``weight_decay``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``rnn_units``
+is capped at 64 — DCGRU activations are (B, T, N, rnn_units) and N=515
+already pushes activation memory.
 """
 
 from gnn_benchmark.models import GTSConfig, GTSModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, gts_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +19,9 @@ run_example(
     model_factory=lambda: GTSModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":           LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay": Categorical([0.0, 1e-5, 1e-4]),
-        "rnn_units":    Categorical([32, 64]),
-    },
+    search_space=gts_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        rnn_units=Categorical([32, 64]),
+    ),
 )

--- a/examples_new/chicago_bikes_gwn_example.py
+++ b/examples_new/chicago_bikes_gwn_example.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """GWN on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Uses the
-``divvy-bikeshare-static`` registry entry, which restricts to a Loop +
-Near North Side + Lincoln Park bbox (N ≈ 515 stations) with a static
-haversine graph sparsified at 2 km.  Capacity axis: ``nhid``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  Uses the
+``divvy-bikeshare-static`` registry entry (N ≈ 515 stations); ``nhid``
+is capped at 32 because GWN's skip/end channels scale as ``nhid * 8 /
+16``.
 """
 
 from gnn_benchmark.models import GWNConfig, GWNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, gwn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -19,9 +20,9 @@ run_example(
     model_factory=lambda: GWNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":      LogUniform(LR_LOW, LR_HIGH),
-        "dropout": Categorical([0.0, 0.1, 0.3]),
-        "nhid":    Categorical([16, 32]),
-    },
+    search_space=gwn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        nhid=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/chicago_bikes_mtgnn_example.py
+++ b/examples_new/chicago_bikes_mtgnn_example.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """MTGNN on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``conv_channels``
+is capped at 32 for the 515-node graph.
 """
 
 from gnn_benchmark.models import MTGNNConfig, MTGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, mtgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +18,9 @@ run_example(
     model_factory=lambda: MTGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3]),
-        "conv_channels": Categorical([16, 32]),
-    },
+    search_space=mtgnn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        conv_channels=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/chicago_bikes_mtgode_example.py
+++ b/examples_new/chicago_bikes_mtgode_example.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """MTGODE on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``conv_channels``
+is capped at 32 for the 515-node graph.
 """
 
 from gnn_benchmark.models import MTGODEConfig, MTGODEModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, mtgode_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +18,9 @@ run_example(
     model_factory=lambda: MTGODEModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3]),
-        "conv_channels": Categorical([16, 32]),
-    },
+    search_space=mtgode_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        conv_channels=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/chicago_bikes_staeformer_example.py
+++ b/examples_new/chicago_bikes_staeformer_example.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """STAEFormer on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``adaptive_embedding_dim``.  ``num_layers=2`` is fixed because spatial
-self-attention scales as N²·heads·layers.  ``num_heads=4`` divides every
-produced model_dim (40, 64).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  Spatial
+self-attention scales as N²·heads·layers, so ``num_layers=2`` is fixed
+in the base config (and dropped from the search) and
+``adaptive_embedding_dim`` is capped at 40 (``model_dim`` ∈ {40, 64}).
+``num_heads=4`` divides every produced model_dim.
 """
 
 from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, staeformer_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -20,13 +22,16 @@ base_config = apply_schedule(
     num_layers=2,
 )
 
+search_space = staeformer_search_space(
+    lr_low=LR_LOW,
+    lr_high=LR_HIGH,
+    adaptive_embedding_dim=Categorical([16, 40]),
+)
+del search_space["num_layers"]  # pinned in base_config for the N=515 graph
+
 run_example(
     model_factory=lambda: STAEFormerModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":                     LogUniform(LR_LOW, LR_HIGH),
-        "dropout":                Categorical([0.0, 0.1, 0.2]),
-        "adaptive_embedding_dim": Categorical([16, 40]),
-    },
+    search_space=search_space,
 )

--- a/examples_new/covid_astgcn_example.py
+++ b/examples_new/covid_astgcn_example.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """ASTGCN on NYC COVID — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``nb_chev_filter``, capped at 64.  Reg axis: ``weight_decay``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``nb_chev_filter``
+is capped at 64 for the 3212-node graph.
 """
 
 from gnn_benchmark.models import ASTGCNConfig, ASTGCNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, astgcn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +18,9 @@ run_example(
     model_factory=lambda: ASTGCNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":             LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay":   Categorical([0.0, 1e-5, 1e-4]),
-        "nb_chev_filter": Categorical([32, 64]),
-    },
+    search_space=astgcn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        nb_chev_filter=Categorical([32, 64]),
+    ),
 )

--- a/examples_new/covid_d2stgnn_example.py
+++ b/examples_new/covid_d2stgnn_example.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """D2STGNN on NYC COVID — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``num_hidden``, capped at 32 because D2STGNN's per-layer N×N dynamic-graph
-scores tensor is ~40 MB at fp32 on N=3212 (gradients double that).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``num_hidden``
+is capped at 32 — D2STGNN's per-layer N×N dynamic-graph scores tensor is
+~40 MB at fp32 on N=3212 (gradients double that).
 """
 
 from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, d2stgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +19,9 @@ run_example(
     model_factory=lambda: D2STGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":         LogUniform(LR_LOW, LR_HIGH),
-        "dropout":    Categorical([0.0, 0.1, 0.2]),
-        "num_hidden": Categorical([16, 32]),
-    },
+    search_space=d2stgnn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        num_hidden=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/covid_gts_example.py
+++ b/examples_new/covid_gts_example.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """GTS on NYC COVID — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``rnn_units``, capped at 64.  GTS materialises an N×N learned graph
-(~10 M cells at N=3212), so the rnn width is the larger memory lever.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``rnn_units``
+is capped at 64 — GTS materialises an N×N learned graph (~10 M cells at
+N=3212), so the rnn width is the larger memory lever.
 """
 
 from gnn_benchmark.models import GTSConfig, GTSModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, gts_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +19,9 @@ run_example(
     model_factory=lambda: GTSModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":           LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay": Categorical([0.0, 1e-5, 1e-4]),
-        "rnn_units":    Categorical([32, 64]),
-    },
+    search_space=gts_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        rnn_units=Categorical([32, 64]),
+    ),
 )

--- a/examples_new/covid_gwn_example.py
+++ b/examples_new/covid_gwn_example.py
@@ -1,27 +1,32 @@
 #!/usr/bin/env python3
 """GWN on NYC COVID (county-level) — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis: ``nhid``,
-capped at 32 (GWN's skip/end channels are 8×/16× nhid; N=3212 makes the
-upper end memory-tight).  ``blocks=2`` is fixed for the same reason; each
-block doubles the dilation footprint.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``nhid`` is
+capped at 32 (skip/end channels are 8×/16× nhid; N=3212 makes the upper
+end memory-tight).  ``blocks=2`` is pinned in the base config (and
+dropped from the search) because each block doubles the dilation
+footprint.
 """
 
 from gnn_benchmark.models import GWNConfig, GWNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, gwn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
 DATASET = "nyc-covid"
 base_config = apply_schedule(GWNConfig(), DATASET, blocks=2)
 
+search_space = gwn_search_space(
+    lr_low=LR_LOW,
+    lr_high=LR_HIGH,
+    nhid=Categorical([16, 32]),
+)
+del search_space["blocks"]  # pinned in base_config for the N=3212 graph
+
 run_example(
     model_factory=lambda: GWNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":      LogUniform(LR_LOW, LR_HIGH),
-        "dropout": Categorical([0.0, 0.1, 0.3]),
-        "nhid":    Categorical([16, 32]),
-    },
+    search_space=search_space,
 )

--- a/examples_new/covid_mtgnn_example.py
+++ b/examples_new/covid_mtgnn_example.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """MTGNN on NYC COVID — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``, capped at 32 for the 3212-node graph.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``conv_channels``
+is capped at 32 for the 3212-node graph.
 """
 
 from gnn_benchmark.models import MTGNNConfig, MTGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, mtgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +18,9 @@ run_example(
     model_factory=lambda: MTGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3]),
-        "conv_channels": Categorical([16, 32]),
-    },
+    search_space=mtgnn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        conv_channels=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/covid_mtgode_example.py
+++ b/examples_new/covid_mtgode_example.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """MTGODE on NYC COVID — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``, capped at 32 for the 3212-node graph.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``conv_channels``
+is capped at 32 for the 3212-node graph.
 """
 
 from gnn_benchmark.models import MTGODEConfig, MTGODEModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, mtgode_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +18,9 @@ run_example(
     model_factory=lambda: MTGODEModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3]),
-        "conv_channels": Categorical([16, 32]),
-    },
+    search_space=mtgode_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        conv_channels=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/covid_staeformer_example.py
+++ b/examples_new/covid_staeformer_example.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """STAEFormer on NYC COVID — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``adaptive_embedding_dim``.  Spatial self-attention scales as N²·heads, so
-on N=3212 we drop ``num_layers`` to 1 and cap adaptive_embedding_dim at 16
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  Spatial
+self-attention scales as N²·heads·layers, so on N=3212 we pin
+``num_layers=1`` and ``feed_forward_dim=128`` in the base config (and
+drop both from the search), and cap ``adaptive_embedding_dim`` at 16
 (``model_dim`` ∈ {32, 40}).  ``num_heads=4`` divides both.
 """
 
 from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, staeformer_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -21,13 +23,18 @@ base_config = apply_schedule(
     feed_forward_dim=128,
 )
 
+search_space = staeformer_search_space(
+    lr_low=LR_LOW,
+    lr_high=LR_HIGH,
+    adaptive_embedding_dim=Categorical([8, 16]),
+)
+# Pinned in base_config for the N=3212 graph.
+del search_space["num_layers"]
+del search_space["feed_forward_dim"]
+
 run_example(
     model_factory=lambda: STAEFormerModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":                     LogUniform(LR_LOW, LR_HIGH),
-        "dropout":                Categorical([0.0, 0.1, 0.2]),
-        "adaptive_embedding_dim": Categorical([8, 16]),
-    },
+    search_space=search_space,
 )

--- a/examples_new/eu_load_astgcn_example.py
+++ b/examples_new/eu_load_astgcn_example.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 """ASTGCN on EU electricity load — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``nb_chev_filter``.  Reg axis: ``weight_decay`` (ASTGCN does not expose
-dropout).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import ASTGCNConfig, ASTGCNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import astgcn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +17,5 @@ run_example(
     model_factory=lambda: ASTGCNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":             LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay":   Categorical([0.0, 1e-5, 1e-4, 1e-3]),
-        "nb_chev_filter": Categorical([32, 64, 128]),
-    },
+    search_space=astgcn_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/eu_load_d2stgnn_example.py
+++ b/examples_new/eu_load_d2stgnn_example.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """D2STGNN on EU electricity load — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``num_hidden``.  Reg axis: ``dropout``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import d2stgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +17,5 @@ run_example(
     model_factory=lambda: D2STGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":         LogUniform(LR_LOW, LR_HIGH),
-        "dropout":    Categorical([0.0, 0.1, 0.2, 0.3]),
-        "num_hidden": Categorical([16, 32, 64]),
-    },
+    search_space=d2stgnn_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/eu_load_gts_example.py
+++ b/examples_new/eu_load_gts_example.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """GTS on EU electricity load — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``rnn_units``.  Reg axis: ``weight_decay`` (GTS does not expose dropout).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import GTSConfig, GTSModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import gts_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +17,5 @@ run_example(
     model_factory=lambda: GTSModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":           LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay": Categorical([0.0, 1e-5, 1e-4, 1e-3]),
-        "rnn_units":    Categorical([32, 64, 96]),
-    },
+    search_space=gts_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/eu_load_gwn_example.py
+++ b/examples_new/eu_load_gwn_example.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """GWN on EU electricity load — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis: ``nhid``.
-Reg axis: ``dropout``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import GWNConfig, GWNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import gwn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +17,5 @@ run_example(
     model_factory=lambda: GWNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":      LogUniform(LR_LOW, LR_HIGH),
-        "dropout": Categorical([0.0, 0.1, 0.3, 0.5]),
-        "nhid":    Categorical([16, 32, 64]),
-    },
+    search_space=gwn_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/eu_load_mtgnn_example.py
+++ b/examples_new/eu_load_mtgnn_example.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """MTGNN on EU electricity load — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``.  Reg axis: ``dropout``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import MTGNNConfig, MTGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import mtgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +17,5 @@ run_example(
     model_factory=lambda: MTGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3, 0.5]),
-        "conv_channels": Categorical([16, 32, 64]),
-    },
+    search_space=mtgnn_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/eu_load_mtgode_example.py
+++ b/examples_new/eu_load_mtgode_example.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """MTGODE on EU electricity load — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``.  Reg axis: ``dropout``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import MTGODEConfig, MTGODEModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import mtgode_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +17,5 @@ run_example(
     model_factory=lambda: MTGODEModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3, 0.5]),
-        "conv_channels": Categorical([16, 32, 64]),
-    },
+    search_space=mtgode_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/eu_load_staeformer_example.py
+++ b/examples_new/eu_load_staeformer_example.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """STAEFormer on EU electricity load — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``adaptive_embedding_dim`` (``model_dim`` = 24 + adaptive_emb).  Reg axis:
-``dropout``.  ``num_heads=4`` is fixed and divides every model_dim this
-search produces (40, 64, 104).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``num_heads=4``
+is fixed in the base config and divides every produced ``model_dim``
+(40, 64, 104).
 """
 
 from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import staeformer_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -19,9 +19,5 @@ run_example(
     model_factory=lambda: STAEFormerModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":                     LogUniform(LR_LOW, LR_HIGH),
-        "dropout":                Categorical([0.0, 0.1, 0.2, 0.3]),
-        "adaptive_embedding_dim": Categorical([16, 40, 80]),
-    },
+    search_space=staeformer_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/lamah_ce_astgcn_example.py
+++ b/examples_new/lamah_ce_astgcn_example.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """ASTGCN on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``nb_chev_filter``, capped at 64.  Reg axis: ``weight_decay``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``nb_chev_filter``
+is capped at 64 for the 859-node graph.
 """
 
 from gnn_benchmark.models import ASTGCNConfig, ASTGCNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, astgcn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +18,9 @@ run_example(
     model_factory=lambda: ASTGCNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":             LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay":   Categorical([0.0, 1e-5, 1e-4]),
-        "nb_chev_filter": Categorical([32, 64]),
-    },
+    search_space=astgcn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        nb_chev_filter=Categorical([32, 64]),
+    ),
 )

--- a/examples_new/lamah_ce_d2stgnn_example.py
+++ b/examples_new/lamah_ce_d2stgnn_example.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """D2STGNN on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``num_hidden``, capped at 32 because D2STGNN holds an N×N dynamic-graph
-scores tensor per layer (N=859 makes the upper end memory-tight).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``num_hidden``
+is capped at 32 — D2STGNN holds an N×N dynamic-graph scores tensor per
+layer (N=859 makes the upper end memory-tight).
 """
 
 from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, d2stgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +19,9 @@ run_example(
     model_factory=lambda: D2STGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":         LogUniform(LR_LOW, LR_HIGH),
-        "dropout":    Categorical([0.0, 0.1, 0.2]),
-        "num_hidden": Categorical([16, 32]),
-    },
+    search_space=d2stgnn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        num_hidden=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/lamah_ce_gts_example.py
+++ b/examples_new/lamah_ce_gts_example.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """GTS on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``rnn_units``, capped at 64 because GTS materialises an N×N learned graph
-and DCGRU activations are (B, T, N, rnn_units).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``rnn_units``
+is capped at 64 — GTS materialises an N×N learned graph and DCGRU
+activations are (B, T, N, rnn_units).
 """
 
 from gnn_benchmark.models import GTSConfig, GTSModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, gts_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +19,9 @@ run_example(
     model_factory=lambda: GTSModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":           LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay": Categorical([0.0, 1e-5, 1e-4]),
-        "rnn_units":    Categorical([32, 64]),
-    },
+    search_space=gts_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        rnn_units=Categorical([32, 64]),
+    ),
 )

--- a/examples_new/lamah_ce_gwn_example.py
+++ b/examples_new/lamah_ce_gwn_example.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """GWN on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis: ``nhid``;
-the upper end is capped at 32 here because GWN's skip/end channels scale
-as ``nhid * 8 / 16`` and N=859 already pushes activation memory.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``nhid`` is
+capped at 32 because GWN's skip/end channels scale as ``nhid * 8 / 16``
+and N=859 already pushes activation memory.
 """
 
 from gnn_benchmark.models import GWNConfig, GWNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, gwn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +19,9 @@ run_example(
     model_factory=lambda: GWNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":      LogUniform(LR_LOW, LR_HIGH),
-        "dropout": Categorical([0.0, 0.1, 0.3]),
-        "nhid":    Categorical([16, 32]),
-    },
+    search_space=gwn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        nhid=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/lamah_ce_mtgnn_example.py
+++ b/examples_new/lamah_ce_mtgnn_example.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """MTGNN on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``, capped at 32 for the 859-node graph.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``conv_channels``
+is capped at 32 for the 859-node graph.
 """
 
 from gnn_benchmark.models import MTGNNConfig, MTGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, mtgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +18,9 @@ run_example(
     model_factory=lambda: MTGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3]),
-        "conv_channels": Categorical([16, 32]),
-    },
+    search_space=mtgnn_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        conv_channels=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/lamah_ce_mtgode_example.py
+++ b/examples_new/lamah_ce_mtgode_example.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 """MTGODE on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``, capped at 32 for the 859-node graph.  ODE solver
-settings are left at MTGODE's defaults to keep the comparison about
-capacity / regularization, not solver choice.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``conv_channels``
+is capped at 32 for the 859-node graph.
 """
 
 from gnn_benchmark.models import MTGODEConfig, MTGODEModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, mtgode_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -19,9 +18,9 @@ run_example(
     model_factory=lambda: MTGODEModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3]),
-        "conv_channels": Categorical([16, 32]),
-    },
+    search_space=mtgode_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+        conv_channels=Categorical([16, 32]),
+    ),
 )

--- a/examples_new/lamah_ce_staeformer_example.py
+++ b/examples_new/lamah_ce_staeformer_example.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """STAEFormer on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``adaptive_embedding_dim``.  Spatial self-attention scales as N²·heads, so
-``num_layers=2`` and the dim values are capped at 40 here for N=859.
-``num_heads=4`` is fixed and divides every produced model_dim (40, 64).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  Spatial
+self-attention scales as N²·heads·layers, so ``num_layers=2`` is fixed
+in the base config (and dropped from the search) and
+``adaptive_embedding_dim`` is capped at 40 (``model_dim`` ∈ {40, 64}).
+``num_heads=4`` divides every produced model_dim.
 """
 
 from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import Categorical, staeformer_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -20,13 +22,16 @@ base_config = apply_schedule(
     num_layers=2,
 )
 
+search_space = staeformer_search_space(
+    lr_low=LR_LOW,
+    lr_high=LR_HIGH,
+    adaptive_embedding_dim=Categorical([16, 40]),
+)
+del search_space["num_layers"]  # pinned in base_config for the N=859 graph
+
 run_example(
     model_factory=lambda: STAEFormerModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":                     LogUniform(LR_LOW, LR_HIGH),
-        "dropout":                Categorical([0.0, 0.1, 0.2]),
-        "adaptive_embedding_dim": Categorical([16, 40]),
-    },
+    search_space=search_space,
 )

--- a/examples_new/noaa_astgcn_example.py
+++ b/examples_new/noaa_astgcn_example.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 """ASTGCN on NOAA buoys — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``nb_chev_filter`` (Chebyshev filter width).  Reg axis: ``weight_decay``
-(ASTGCN does not expose dropout).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import ASTGCNConfig, ASTGCNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import astgcn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +17,5 @@ run_example(
     model_factory=lambda: ASTGCNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":             LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay":   Categorical([0.0, 1e-5, 1e-4, 1e-3]),
-        "nb_chev_filter": Categorical([32, 64, 128]),
-    },
+    search_space=astgcn_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/noaa_d2stgnn_example.py
+++ b/examples_new/noaa_d2stgnn_example.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """D2STGNN on NOAA buoys — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``num_hidden``.  Reg axis: ``dropout`` (D2STGNN's default 0.1 is included).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import D2STGNNConfig, D2STGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import d2stgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +17,5 @@ run_example(
     model_factory=lambda: D2STGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":         LogUniform(LR_LOW, LR_HIGH),
-        "dropout":    Categorical([0.0, 0.1, 0.2, 0.3]),
-        "num_hidden": Categorical([16, 32, 64]),
-    },
+    search_space=d2stgnn_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/noaa_gts_example.py
+++ b/examples_new/noaa_gts_example.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 """GTS on NOAA buoys — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``rnn_units`` (DCGRU width).  Reg axis: ``weight_decay`` (GTS does not
-expose dropout).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import GTSConfig, GTSModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import gts_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +17,5 @@ run_example(
     model_factory=lambda: GTSModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":           LogUniform(LR_LOW, LR_HIGH),
-        "weight_decay": Categorical([0.0, 1e-5, 1e-4, 1e-3]),
-        "rnn_units":    Categorical([32, 64, 96]),
-    },
+    search_space=gts_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/noaa_gwn_example.py
+++ b/examples_new/noaa_gwn_example.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 """GWN on NOAA buoys — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol (random search, 12 trials,
-log-uniform LR, dataset-pinned training schedule).  Capacity axis: ``nhid``,
-GWN's residual / dilation channel width.  Reg axis: ``dropout``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import GWNConfig, GWNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import gwn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -18,9 +17,5 @@ run_example(
     model_factory=lambda: GWNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":      LogUniform(LR_LOW, LR_HIGH),
-        "dropout": Categorical([0.0, 0.1, 0.3, 0.5]),
-        "nhid":    Categorical([16, 32, 64]),
-    },
+    search_space=gwn_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/noaa_mtgnn_example.py
+++ b/examples_new/noaa_mtgnn_example.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """MTGNN on NOAA buoys — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels`` (the TCN/GCN width).  Reg axis: ``dropout``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import MTGNNConfig, MTGNNModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import mtgnn_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +17,5 @@ run_example(
     model_factory=lambda: MTGNNModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3, 0.5]),
-        "conv_channels": Categorical([16, 32, 64]),
-    },
+    search_space=mtgnn_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/noaa_mtgode_example.py
+++ b/examples_new/noaa_mtgode_example.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """MTGODE on NOAA buoys — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``conv_channels``.  Reg axis: ``dropout``.
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
 """
 
 from gnn_benchmark.models import MTGODEConfig, MTGODEModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import mtgode_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -17,9 +17,5 @@ run_example(
     model_factory=lambda: MTGODEModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":            LogUniform(LR_LOW, LR_HIGH),
-        "dropout":       Categorical([0.0, 0.1, 0.3, 0.5]),
-        "conv_channels": Categorical([16, 32, 64]),
-    },
+    search_space=mtgode_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/examples_new/noaa_staeformer_example.py
+++ b/examples_new/noaa_staeformer_example.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """STAEFormer on NOAA buoys — fair-protocol hyperparameter tuning.
 
-See ``examples_new/_shared.py`` for the protocol.  Capacity axis:
-``adaptive_embedding_dim`` (drives ``model_dim`` = 24 + adaptive_emb).  Reg
-axis: ``dropout``.  ``num_heads=4`` is fixed and divides every model_dim
-this search produces (40, 64, 104).
+See ``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.  ``num_heads=4``
+is fixed in the base config and divides every produced
+``model_dim = input_embedding_dim + adaptive_embedding_dim``
+(40, 64, 104).
 """
 
 from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
-from gnn_benchmark.tuning import Categorical, LogUniform
+from gnn_benchmark.tuning import staeformer_search_space
 
 from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
 
@@ -19,9 +20,5 @@ run_example(
     model_factory=lambda: STAEFormerModel(),
     base_config=base_config,
     dataset_key=DATASET,
-    search_space={
-        "lr":                     LogUniform(LR_LOW, LR_HIGH),
-        "dropout":                Categorical([0.0, 0.1, 0.2, 0.3]),
-        "adaptive_embedding_dim": Categorical([16, 40, 80]),
-    },
+    search_space=staeformer_search_space(lr_low=LR_LOW, lr_high=LR_HIGH),
 )

--- a/models/gts.py
+++ b/models/gts.py
@@ -84,7 +84,11 @@ class GTSConfig:
     #   loss_total = loss_pred + bce_weight * BCE(learned_adj, adj)
     # for the first ``epoch_use_regularization`` epochs.
     bce_weight: float = 1.0
-    epoch_use_regularization: int = 0
+    # Default to 5 epochs of BCE regularization so GTS uses *both* the
+    # learned latent graph and the provided adjacency when one is
+    # available.  The gating in ``fit`` is no-op when adj is None or
+    # ``bce_weight`` is 0, so this default is safe in either case.
+    epoch_use_regularization: int = 5
 
     # LR scheduler (multi-step)
     use_lr_scheduler: bool = True

--- a/models/mtgnn.py
+++ b/models/mtgnn.py
@@ -231,6 +231,19 @@ class MTGNNModel(BenchmarkModel):
             shuffle=False,
         )
 
+        # -- Predefined adjacency ------------------------------------------
+        # MTGNN's graph mode is exclusive: when ``buildA_true=True`` it
+        # learns a graph from scratch and the predefined adjacency is
+        # ignored; when ``buildA_true=False`` it reads from
+        # ``predefined_A`` instead.  We forward the provided ``adj`` so
+        # the second mode is actually usable end-to-end (callers can
+        # tune ``buildA_true`` to compare the two).
+        predefined_A: torch.Tensor | None = None
+        if not cfg.buildA_true and adj is not None:
+            predefined_A = torch.tensor(
+                np.asarray(adj, dtype=np.float32), device=device,
+            )
+
         # -- Build model ---------------------------------------------------
         model = gtnet(
             gcn_true=cfg.gcn_true,
@@ -238,7 +251,7 @@ class MTGNNModel(BenchmarkModel):
             gcn_depth=cfg.gcn_depth,
             num_nodes=num_nodes,
             device=device,
-            predefined_A=None,
+            predefined_A=predefined_A,
             static_feat=None,
             dropout=cfg.dropout,
             # `subgraph_size` is the top-k neighbours per node inside MTGNN's

--- a/models/mtgode.py
+++ b/models/mtgode.py
@@ -244,12 +244,24 @@ class MTGODEModel(BenchmarkModel):
             shuffle=False,
         )
 
+        # -- Predefined adjacency ------------------------------------------
+        # MTGODE's graph mode is exclusive: when ``buildA_true=True`` it
+        # learns a graph via its graph constructor; when
+        # ``buildA_true=False`` it reads from ``predefined_A`` instead.
+        # We forward the provided ``adj`` so the second mode is actually
+        # usable (callers can tune ``buildA_true`` to compare the two).
+        predefined_A: torch.Tensor | None = None
+        if not cfg.buildA_true and adj is not None:
+            predefined_A = torch.tensor(
+                np.asarray(adj, dtype=np.float32), device=device,
+            )
+
         # -- Build model ---------------------------------------------------
         model = MTGODE(
             buildA_true=cfg.buildA_true,
             num_nodes=num_nodes,
             device=device,
-            predefined_A=None,
+            predefined_A=predefined_A,
             static_feat=None,
             dropout=cfg.dropout,
             # `subgraph_size` is the top-k neighbours per node inside MTGODE's

--- a/tuning/__init__.py
+++ b/tuning/__init__.py
@@ -9,6 +9,10 @@ Public entry points:
 - :class:`Categorical`, :class:`IntUniform`, :class:`Uniform`,
   :class:`LogUniform` — search-space primitives, shaped to match Optuna's
   ``trial.suggest_*`` API.
+- ``gnn_benchmark.tuning.spaces`` — per-model default search-space
+  factories (``gwn_search_space``, ``mtgnn_search_space``, …).  Each
+  factory returns a fresh dict and accepts ``**overrides`` for
+  per-dataset capping.
 """
 
 from gnn_benchmark.tuning.search_space import (
@@ -17,6 +21,17 @@ from gnn_benchmark.tuning.search_space import (
     LogUniform,
     Sampler,
     Uniform,
+)
+from gnn_benchmark.tuning.spaces import (
+    DEFAULT_LR_HIGH,
+    DEFAULT_LR_LOW,
+    astgcn_search_space,
+    d2stgnn_search_space,
+    gts_search_space,
+    gwn_search_space,
+    mtgnn_search_space,
+    mtgode_search_space,
+    staeformer_search_space,
 )
 from gnn_benchmark.tuning.tuner import (
     HyperparameterTuner,
@@ -33,4 +48,13 @@ __all__ = [
     "IntUniform",
     "Uniform",
     "LogUniform",
+    "DEFAULT_LR_LOW",
+    "DEFAULT_LR_HIGH",
+    "gwn_search_space",
+    "mtgnn_search_space",
+    "gts_search_space",
+    "d2stgnn_search_space",
+    "astgcn_search_space",
+    "staeformer_search_space",
+    "mtgode_search_space",
 ]

--- a/tuning/spaces.py
+++ b/tuning/spaces.py
@@ -1,0 +1,236 @@
+"""Per-model default hyperparameter search spaces.
+
+Each model has knobs that are *hugely* influential and that a generic
+"lr + one reg knob + one capacity knob" search would silently leave at
+a poor fixed value (e.g. ASTGCN's Chebyshev order ``K``, GWN's
+``addaptadj`` toggle, MTGODE's ODE step, transformer depth for
+STAEFormer).  This module provides one factory per model that returns
+the model's default search space — covering the shared training axis
+(``lr``), one regularization axis, one capacity axis, plus 1-2
+model-specific high-impact knobs.
+
+Each factory returns a fresh ``dict[str, Sampler]`` and accepts
+``**overrides`` so dataset-specific examples can replace a single
+dimension (typically to cap a capacity axis for memory) without having
+to rewrite the rest of the space::
+
+    from gnn_benchmark.tuning.spaces import gwn_search_space
+    from gnn_benchmark.tuning import Categorical
+
+    # Default GWN search space.
+    space = gwn_search_space()
+
+    # Same space, but cap nhid for a large graph.
+    space = gwn_search_space(nhid=Categorical([16, 32]))
+
+    # Drop a dimension entirely.
+    space = gwn_search_space()
+    del space["blocks"]
+
+The tuner validates every key against the relevant ``*Config``
+dataclass (see ``tuning/tuner.py``) so typos and unknown fields fail
+fast.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gnn_benchmark.tuning.search_space import (
+    Categorical,
+    LogUniform,
+    Sampler,
+)
+
+__all__ = [
+    "DEFAULT_LR_LOW",
+    "DEFAULT_LR_HIGH",
+    "gwn_search_space",
+    "mtgnn_search_space",
+    "gts_search_space",
+    "d2stgnn_search_space",
+    "astgcn_search_space",
+    "staeformer_search_space",
+    "mtgode_search_space",
+]
+
+
+# Common LR range, log-uniform.  Spans roughly the published defaults
+# across the wrapped models (1e-3 for GWN/MTGNN/STAEFormer/ASTGCN/MTGODE,
+# 2e-3 for D2STGNN, 5e-3 for GTS), with ~one decade of headroom on each
+# side.  Override per call via ``lr_low``/``lr_high``.
+DEFAULT_LR_LOW = 1e-4
+DEFAULT_LR_HIGH = 5e-3
+
+
+def _build(
+    space: dict[str, Sampler], overrides: dict[str, Any],
+) -> dict[str, Sampler]:
+    space.update(overrides)
+    return space
+
+
+def gwn_search_space(
+    lr_low: float = DEFAULT_LR_LOW,
+    lr_high: float = DEFAULT_LR_HIGH,
+    **overrides: Sampler,
+) -> dict[str, Sampler]:
+    """GWN: lr + dropout + nhid + addaptadj + blocks.
+
+    ``addaptadj`` toggles GWN's adaptive adjacency on top of the
+    provided supports — flipping it changes whether the model uses
+    the provided graph alone or both the provided graph and a learned
+    one.  ``blocks`` controls the depth of the residual TCN/GCN stack.
+    """
+    return _build(
+        {
+            "lr":        LogUniform(lr_low, lr_high),
+            "dropout":   Categorical([0.0, 0.1, 0.3, 0.5]),
+            "nhid":      Categorical([16, 32, 64]),
+            "addaptadj": Categorical([True, False]),
+            "blocks":    Categorical([2, 3, 4]),
+        },
+        overrides,
+    )
+
+
+def mtgnn_search_space(
+    lr_low: float = DEFAULT_LR_LOW,
+    lr_high: float = DEFAULT_LR_HIGH,
+    **overrides: Sampler,
+) -> dict[str, Sampler]:
+    """MTGNN: lr + dropout + conv_channels + buildA_true + propalpha.
+
+    ``buildA_true`` picks between a learned graph constructor and the
+    provided adjacency (architecturally exclusive in MTGNN).
+    ``propalpha`` controls graph-propagation strength and is well-known
+    to dominate val loss when wrong.
+    """
+    return _build(
+        {
+            "lr":            LogUniform(lr_low, lr_high),
+            "dropout":       Categorical([0.0, 0.1, 0.3, 0.5]),
+            "conv_channels": Categorical([16, 32, 64]),
+            "buildA_true":   Categorical([True, False]),
+            "propalpha":     Categorical([0.05, 0.1, 0.2]),
+        },
+        overrides,
+    )
+
+
+def gts_search_space(
+    lr_low: float = DEFAULT_LR_LOW,
+    lr_high: float = DEFAULT_LR_HIGH,
+    **overrides: Sampler,
+) -> dict[str, Sampler]:
+    """GTS: lr + weight_decay + rnn_units + max_diffusion_step + temperature.
+
+    GTS doesn't expose dropout, so weight_decay is the regularization
+    axis.  ``max_diffusion_step`` sets the diffusion-conv expressiveness
+    (paper default 3) and ``temperature`` controls how hard/soft the
+    learned latent graph is — both materially shift convergence.
+    """
+    return _build(
+        {
+            "lr":                 LogUniform(lr_low, lr_high),
+            "weight_decay":       Categorical([0.0, 1e-5, 1e-4, 1e-3]),
+            "rnn_units":          Categorical([32, 64, 96]),
+            "max_diffusion_step": Categorical([2, 3]),
+            "temperature":        Categorical([0.1, 0.5, 1.0]),
+        },
+        overrides,
+    )
+
+
+def d2stgnn_search_space(
+    lr_low: float = DEFAULT_LR_LOW,
+    lr_high: float = DEFAULT_LR_HIGH,
+    **overrides: Sampler,
+) -> dict[str, Sampler]:
+    """D2STGNN: lr + dropout + num_hidden + k_s + k_t.
+
+    ``k_s`` is the spatial-diffusion order (the same kind of knob as
+    ASTGCN's ``K`` — small integer changes have outsized effects).
+    ``k_t`` is the temporal kernel size.
+    """
+    return _build(
+        {
+            "lr":         LogUniform(lr_low, lr_high),
+            "dropout":    Categorical([0.0, 0.1, 0.2, 0.3]),
+            "num_hidden": Categorical([16, 32, 64]),
+            "k_s":        Categorical([1, 2, 3]),
+            "k_t":        Categorical([2, 3, 4]),
+        },
+        overrides,
+    )
+
+
+def astgcn_search_space(
+    lr_low: float = DEFAULT_LR_LOW,
+    lr_high: float = DEFAULT_LR_HIGH,
+    **overrides: Sampler,
+) -> dict[str, Sampler]:
+    """ASTGCN: lr + weight_decay + nb_chev_filter + K + nb_block.
+
+    ``K`` is ASTGCN's Chebyshev order — the most influential ASTGCN
+    knob.  ``nb_block`` controls depth.
+    """
+    return _build(
+        {
+            "lr":             LogUniform(lr_low, lr_high),
+            "weight_decay":   Categorical([0.0, 1e-5, 1e-4, 1e-3]),
+            "nb_chev_filter": Categorical([32, 64, 128]),
+            "K":              Categorical([2, 3, 4]),
+            "nb_block":       Categorical([1, 2, 3]),
+        },
+        overrides,
+    )
+
+
+def staeformer_search_space(
+    lr_low: float = DEFAULT_LR_LOW,
+    lr_high: float = DEFAULT_LR_HIGH,
+    **overrides: Sampler,
+) -> dict[str, Sampler]:
+    """STAEFormer: lr + dropout + adaptive_embedding_dim + num_layers + feed_forward_dim.
+
+    Transformer val loss is highly sensitive to depth (``num_layers``)
+    and FFN width (``feed_forward_dim``).  ``adaptive_embedding_dim``
+    drives the model_dim alongside the fixed ``input_embedding_dim``;
+    callers needing a particular ``num_heads`` divisibility should
+    override either of them.
+    """
+    return _build(
+        {
+            "lr":                     LogUniform(lr_low, lr_high),
+            "dropout":                Categorical([0.0, 0.1, 0.2, 0.3]),
+            "adaptive_embedding_dim": Categorical([16, 40, 80]),
+            "num_layers":             Categorical([2, 3, 4]),
+            "feed_forward_dim":       Categorical([128, 256, 512]),
+        },
+        overrides,
+    )
+
+
+def mtgode_search_space(
+    lr_low: float = DEFAULT_LR_LOW,
+    lr_high: float = DEFAULT_LR_HIGH,
+    **overrides: Sampler,
+) -> dict[str, Sampler]:
+    """MTGODE: lr + dropout + conv_channels + buildA_true + step_1.
+
+    Like MTGNN, ``buildA_true`` selects between learned and provided
+    graphs.  ``step_1`` is the Continuous Temporal Aggregation ODE
+    step size — coarser steps train faster but lose accuracy, finer
+    steps converge to better val loss but cost more compute.
+    """
+    return _build(
+        {
+            "lr":            LogUniform(lr_low, lr_high),
+            "dropout":       Categorical([0.0, 0.1, 0.3, 0.5]),
+            "conv_channels": Categorical([16, 32, 64]),
+            "buildA_true":   Categorical([True, False]),
+            "step_1":        Categorical([0.125, 0.25, 0.5]),
+        },
+        overrides,
+    )


### PR DESCRIPTION
The fair protocol used the same search-space *shape* for every model
(lr + 1 reg knob + 1 capacity knob), which silently left huge-impact
knobs at fixed defaults: ASTGCN's Chebyshev order K, GWN's addaptadj
toggle, MTGODE's ODE step, transformer depth for STAEFormer, etc.
A poor original choice for any of those would cascade into bad results
for that model and skew the cross-model comparison.

  * New `tuning/spaces.py` exposes a `_search_space()` factory per
    model, each covering shared `lr` + reg axis + 1-2 high-impact
    model-specific knobs (5 dims total).
  * Bump `N_TRIALS` from 12 to 18 to compensate for the extra dims.
  * Fix MTGNN/MTGODE wrappers to forward `adj` when `buildA_true=False`
    so the predefined-adjacency mode is actually usable end-to-end and
    `buildA_true` becomes meaningfully tunable.
  * Turn on GTS BCE regularization by default (`epoch_use_regularization=5`)
    so the default config uses *both* the learned latent graph and the
    provided adjacency.
  * Refactor all 35 examples to call the per-model factory and apply
    per-dataset memory caps via `**overrides`.