### PR TITLE
Add per-dataset MLP baseline tuning scripts

### DIFF
--- a/examples_baseline/chicago_bikes_mlp_example.py
+++ b/examples_baseline/chicago_bikes_mlp_example.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""MLP on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
+
+Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
+identical protocol (18 random trials, seed 0, dataset training schedule
+from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
+test-set numbers are directly comparable.  See
+``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+"""
+
+import sys
+from pathlib import Path
+
+# Reuse the new-examples protocol helper without duplicating it.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
+
+from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
+from gnn_benchmark.tuning import mlp_multivariate_search_space
+
+from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+
+DATASET = "divvy-bikeshare-static"
+base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
+
+run_example(
+    model_factory=lambda: MLPMultivariateModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    search_space=mlp_multivariate_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+    ),
+)

--- a/examples_baseline/covid_mlp_example.py
+++ b/examples_baseline/covid_mlp_example.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""MLP on NYC COVID (county-level) — fair-protocol hyperparameter tuning.
+
+Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
+identical protocol (18 random trials, seed 0, dataset training schedule
+from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
+test-set numbers are directly comparable.  See
+``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+"""
+
+import sys
+from pathlib import Path
+
+# Reuse the new-examples protocol helper without duplicating it.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
+
+from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
+from gnn_benchmark.tuning import mlp_multivariate_search_space
+
+from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+
+DATASET = "nyc-covid"
+base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
+
+run_example(
+    model_factory=lambda: MLPMultivariateModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    search_space=mlp_multivariate_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+    ),
+)

--- a/examples_baseline/eu_load_mlp_example.py
+++ b/examples_baseline/eu_load_mlp_example.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""MLP on EU electricity load — fair-protocol hyperparameter tuning.
+
+Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
+identical protocol (18 random trials, seed 0, dataset training schedule
+from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
+test-set numbers are directly comparable.  See
+``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+"""
+
+import sys
+from pathlib import Path
+
+# Reuse the new-examples protocol helper without duplicating it.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
+
+from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
+from gnn_benchmark.tuning import mlp_multivariate_search_space
+
+from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+
+DATASET = "eu-load"
+base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
+
+run_example(
+    model_factory=lambda: MLPMultivariateModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    search_space=mlp_multivariate_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+    ),
+)

--- a/examples_baseline/lamah_ce_mlp_example.py
+++ b/examples_baseline/lamah_ce_mlp_example.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""MLP on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
+
+Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
+identical protocol (18 random trials, seed 0, dataset training schedule
+from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
+test-set numbers are directly comparable.  See
+``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+"""
+
+import sys
+from pathlib import Path
+
+# Reuse the new-examples protocol helper without duplicating it.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
+
+from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
+from gnn_benchmark.tuning import mlp_multivariate_search_space
+
+from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+
+DATASET = "lamah-ce-dynamic"
+base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
+
+run_example(
+    model_factory=lambda: MLPMultivariateModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    search_space=mlp_multivariate_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+    ),
+)

--- a/examples_baseline/noaa_mlp_example.py
+++ b/examples_baseline/noaa_mlp_example.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""MLP on NOAA buoys — fair-protocol hyperparameter tuning.
+
+Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
+identical protocol (18 random trials, seed 0, dataset training schedule
+from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
+test-set numbers are directly comparable.  See
+``examples_new/_shared.py`` for the protocol; the per-model search
+space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+"""
+
+import sys
+from pathlib import Path
+
+# Reuse the new-examples protocol helper without duplicating it.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
+
+from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
+from gnn_benchmark.tuning import mlp_multivariate_search_space
+
+from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+
+DATASET = "noaa-buoy"
+base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
+
+run_example(
+    model_factory=lambda: MLPMultivariateModel(),
+    base_config=base_config,
+    dataset_key=DATASET,
+    search_space=mlp_multivariate_search_space(
+        lr_low=LR_LOW,
+        lr_high=LR_HIGH,
+    ),
+)


### PR DESCRIPTION
Adds five MLPMultivariateModel hyperparameter-tuning scripts under
examples_baseline/, one per major dataset (NOAA buoy, EU load,
LamaH-CE dynamic, NYC COVID, Divvy bikeshare).  Each script reuses
the fair-protocol helpers from examples_new/_shared.py so the MLP
baseline runs the same 18-trial random search and dataset training
schedule as the GNN models, making the resulting test-set numbers
directly comparable.

https://claude.ai/code/session_01Rtrn3mfErWZLdgH1ZsChHa