### PR TITLE
Run MLP baseline examples as single-shot benchmarks (remove tuning)

### DIFF
--- a/examples_baseline/chicago_bikes_mlp_example.py
+++ b/examples_baseline/chicago_bikes_mlp_example.py
@@ -1,34 +1,37 @@
 #!/usr/bin/env python3
-"""MLP on Chicago / Divvy bikeshare — fair-protocol hyperparameter tuning.
+"""MLP baseline single-run benchmark (no hyperparameter tuning).
 
-Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
-identical protocol (18 random trials, seed 0, dataset training schedule
-from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
-test-set numbers are directly comparable.  See
-``examples_new/_shared.py`` for the protocol; the per-model search
-space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+This baseline counterpart to the GNN scripts in ``examples_new/`` keeps the
+same dataset-specific training schedule from ``DATASET_SCHEDULE`` but runs only
+one final evaluation with a hand-picked strong MLP configuration.
 """
 
 import sys
 from pathlib import Path
 
-# Reuse the new-examples protocol helper without duplicating it.
+# Reuse the new-examples schedule helper without duplicating it.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
 
+from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
-from gnn_benchmark.tuning import mlp_multivariate_search_space
 
-from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+from _shared import WORKSPACE, apply_schedule
 
 DATASET = "divvy-bikeshare-static"
-base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
-
-run_example(
-    model_factory=lambda: MLPMultivariateModel(),
-    base_config=base_config,
-    dataset_key=DATASET,
-    search_space=mlp_multivariate_search_space(
-        lr_low=LR_LOW,
-        lr_high=LR_HIGH,
+# Chosen as a robust single-run setting from prior MLP tuning trends.
+base_config = apply_schedule(
+    MLPMultivariateConfig(
+        lr=2e-3,
+        hidden_size=1024,
+        num_layers=3,
+        dropout=0.2,
+        weight_decay=5e-5,
+        seed=0,
     ),
+    DATASET,
 )
+
+print(f"[example] MLPMultivariate on {DATASET} — single run (no tuning)")
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(MLPMultivariateModel(), config=base_config)
+print(result.summary())

--- a/examples_baseline/covid_mlp_example.py
+++ b/examples_baseline/covid_mlp_example.py
@@ -1,34 +1,37 @@
 #!/usr/bin/env python3
-"""MLP on NYC COVID (county-level) — fair-protocol hyperparameter tuning.
+"""MLP baseline single-run benchmark (no hyperparameter tuning).
 
-Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
-identical protocol (18 random trials, seed 0, dataset training schedule
-from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
-test-set numbers are directly comparable.  See
-``examples_new/_shared.py`` for the protocol; the per-model search
-space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+This baseline counterpart to the GNN scripts in ``examples_new/`` keeps the
+same dataset-specific training schedule from ``DATASET_SCHEDULE`` but runs only
+one final evaluation with a hand-picked strong MLP configuration.
 """
 
 import sys
 from pathlib import Path
 
-# Reuse the new-examples protocol helper without duplicating it.
+# Reuse the new-examples schedule helper without duplicating it.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
 
+from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
-from gnn_benchmark.tuning import mlp_multivariate_search_space
 
-from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+from _shared import WORKSPACE, apply_schedule
 
 DATASET = "nyc-covid"
-base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
-
-run_example(
-    model_factory=lambda: MLPMultivariateModel(),
-    base_config=base_config,
-    dataset_key=DATASET,
-    search_space=mlp_multivariate_search_space(
-        lr_low=LR_LOW,
-        lr_high=LR_HIGH,
+# Chosen as a robust single-run setting from prior MLP tuning trends.
+base_config = apply_schedule(
+    MLPMultivariateConfig(
+        lr=2e-3,
+        hidden_size=1024,
+        num_layers=3,
+        dropout=0.2,
+        weight_decay=5e-5,
+        seed=0,
     ),
+    DATASET,
 )
+
+print(f"[example] MLPMultivariate on {DATASET} — single run (no tuning)")
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(MLPMultivariateModel(), config=base_config)
+print(result.summary())

--- a/examples_baseline/eu_load_mlp_example.py
+++ b/examples_baseline/eu_load_mlp_example.py
@@ -1,34 +1,37 @@
 #!/usr/bin/env python3
-"""MLP on EU electricity load — fair-protocol hyperparameter tuning.
+"""MLP baseline single-run benchmark (no hyperparameter tuning).
 
-Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
-identical protocol (18 random trials, seed 0, dataset training schedule
-from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
-test-set numbers are directly comparable.  See
-``examples_new/_shared.py`` for the protocol; the per-model search
-space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+This baseline counterpart to the GNN scripts in ``examples_new/`` keeps the
+same dataset-specific training schedule from ``DATASET_SCHEDULE`` but runs only
+one final evaluation with a hand-picked strong MLP configuration.
 """
 
 import sys
 from pathlib import Path
 
-# Reuse the new-examples protocol helper without duplicating it.
+# Reuse the new-examples schedule helper without duplicating it.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
 
+from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
-from gnn_benchmark.tuning import mlp_multivariate_search_space
 
-from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+from _shared import WORKSPACE, apply_schedule
 
 DATASET = "eu-load"
-base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
-
-run_example(
-    model_factory=lambda: MLPMultivariateModel(),
-    base_config=base_config,
-    dataset_key=DATASET,
-    search_space=mlp_multivariate_search_space(
-        lr_low=LR_LOW,
-        lr_high=LR_HIGH,
+# Chosen as a robust single-run setting from prior MLP tuning trends.
+base_config = apply_schedule(
+    MLPMultivariateConfig(
+        lr=2e-3,
+        hidden_size=1024,
+        num_layers=3,
+        dropout=0.2,
+        weight_decay=5e-5,
+        seed=0,
     ),
+    DATASET,
 )
+
+print(f"[example] MLPMultivariate on {DATASET} — single run (no tuning)")
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(MLPMultivariateModel(), config=base_config)
+print(result.summary())

--- a/examples_baseline/lamah_ce_mlp_example.py
+++ b/examples_baseline/lamah_ce_mlp_example.py
@@ -1,34 +1,37 @@
 #!/usr/bin/env python3
-"""MLP on LamaH-CE (dynamic) — fair-protocol hyperparameter tuning.
+"""MLP baseline single-run benchmark (no hyperparameter tuning).
 
-Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
-identical protocol (18 random trials, seed 0, dataset training schedule
-from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
-test-set numbers are directly comparable.  See
-``examples_new/_shared.py`` for the protocol; the per-model search
-space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+This baseline counterpart to the GNN scripts in ``examples_new/`` keeps the
+same dataset-specific training schedule from ``DATASET_SCHEDULE`` but runs only
+one final evaluation with a hand-picked strong MLP configuration.
 """
 
 import sys
 from pathlib import Path
 
-# Reuse the new-examples protocol helper without duplicating it.
+# Reuse the new-examples schedule helper without duplicating it.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
 
+from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
-from gnn_benchmark.tuning import mlp_multivariate_search_space
 
-from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+from _shared import WORKSPACE, apply_schedule
 
 DATASET = "lamah-ce-dynamic"
-base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
-
-run_example(
-    model_factory=lambda: MLPMultivariateModel(),
-    base_config=base_config,
-    dataset_key=DATASET,
-    search_space=mlp_multivariate_search_space(
-        lr_low=LR_LOW,
-        lr_high=LR_HIGH,
+# Chosen as a robust single-run setting from prior MLP tuning trends.
+base_config = apply_schedule(
+    MLPMultivariateConfig(
+        lr=2e-3,
+        hidden_size=1024,
+        num_layers=3,
+        dropout=0.2,
+        weight_decay=5e-5,
+        seed=0,
     ),
+    DATASET,
 )
+
+print(f"[example] MLPMultivariate on {DATASET} — single run (no tuning)")
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(MLPMultivariateModel(), config=base_config)
+print(result.summary())

--- a/examples_baseline/noaa_mlp_example.py
+++ b/examples_baseline/noaa_mlp_example.py
@@ -1,34 +1,37 @@
 #!/usr/bin/env python3
-"""MLP on NOAA buoys — fair-protocol hyperparameter tuning.
+"""MLP baseline single-run benchmark (no hyperparameter tuning).
 
-Baseline counterpart to the GNN scripts in ``examples_new/`` — runs the
-identical protocol (18 random trials, seed 0, dataset training schedule
-from ``DATASET_SCHEDULE``) on ``MLPMultivariateModel`` so the resulting
-test-set numbers are directly comparable.  See
-``examples_new/_shared.py`` for the protocol; the per-model search
-space is defined in :mod:`gnn_benchmark.tuning.spaces`.
+This baseline counterpart to the GNN scripts in ``examples_new/`` keeps the
+same dataset-specific training schedule from ``DATASET_SCHEDULE`` but runs only
+one final evaluation with a hand-picked strong MLP configuration.
 """
 
 import sys
 from pathlib import Path
 
-# Reuse the new-examples protocol helper without duplicating it.
+# Reuse the new-examples schedule helper without duplicating it.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "examples_new"))
 
+from gnn_benchmark.benchmark import BenchmarkRunner
 from gnn_benchmark.models import MLPMultivariateConfig, MLPMultivariateModel
-from gnn_benchmark.tuning import mlp_multivariate_search_space
 
-from _shared import LR_HIGH, LR_LOW, apply_schedule, run_example
+from _shared import WORKSPACE, apply_schedule
 
 DATASET = "noaa-buoy"
-base_config = apply_schedule(MLPMultivariateConfig(), DATASET)
-
-run_example(
-    model_factory=lambda: MLPMultivariateModel(),
-    base_config=base_config,
-    dataset_key=DATASET,
-    search_space=mlp_multivariate_search_space(
-        lr_low=LR_LOW,
-        lr_high=LR_HIGH,
+# Chosen as a robust single-run setting from prior MLP tuning trends.
+base_config = apply_schedule(
+    MLPMultivariateConfig(
+        lr=2e-3,
+        hidden_size=1024,
+        num_layers=3,
+        dropout=0.2,
+        weight_decay=5e-5,
+        seed=0,
     ),
+    DATASET,
 )
+
+print(f"[example] MLPMultivariate on {DATASET} — single run (no tuning)")
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(MLPMultivariateModel(), config=base_config)
+print(result.summary())


### PR DESCRIPTION
### Motivation
- The baseline MLP example scripts currently run the fair hyperparameter tuning protocol (`N_TRIALS=18`) which is unnecessary for single-run baseline comparisons and slows down example execution. 
- The goal is to replace multi-trial tuning with a single, hand-picked MLP configuration to maximise one-run performance and simplify the examples.

### Description
- Replaced the tuning flow in the Python examples under `examples_baseline/*_mlp_example.py` with a one-shot benchmark that uses `BenchmarkRunner` directly. 
- Removed tuning-specific imports and `run_example(...)`/`mlp_multivariate_search_space(...)` usage and instead construct a fixed `MLPMultivariateConfig` applied via `apply_schedule`. 
- Chose a single fixed hyperparameter set intended for strong one-run performance: `lr=2e-3`, `hidden_size=1024`, `num_layers=3`, `dropout=0.2`, `weight_decay=5e-5`, and `seed=0`. 
- Updated module docstrings to describe the new single-run behaviour while keeping dataset-specific training schedule application from `examples_new/_shared.py`.

### Testing
- Ran `python -m py_compile examples_baseline/*_mlp_example.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e71b2a58832085590927b662e6fb)