### PR TITLE
Fix LastValueModel to handle multi-feature inputs correctly

### DIFF
--- a/models/last_value.py
+++ b/models/last_value.py
@@ -23,6 +23,7 @@ class LastValueModel(BenchmarkModel):
 
     def __init__(self) -> None:
         self._horizon: int | None = None
+        self._output_dim: int | None = None
 
     @property
     def name(self) -> str:
@@ -38,6 +39,7 @@ class LastValueModel(BenchmarkModel):
         config: Any,
     ) -> TrainingHistory | None:
         self._horizon = y_train.shape[1]
+        self._output_dim = y_train.shape[3]
         return None
 
     def predict(
@@ -50,16 +52,17 @@ class LastValueModel(BenchmarkModel):
         Repeat the last observed input timestep for each forecast horizon step.
 
         Args:
-            x_test: ``[S, L, N, D]`` input windows (torch.Tensor or ndarray).
+            x_test: ``[S, L, N, D_in]`` input windows (torch.Tensor or ndarray).
             adj:    Ignored.
             config: Ignored.
 
         Returns:
-            ``np.ndarray`` of shape ``[S, H, N, D]`` where every horizon step
-            equals the last non-NaN value of the corresponding input window,
-            or 0 where the entire (node, feature) series is missing.
+            ``np.ndarray`` of shape ``[S, H, N, D_out]`` where every horizon
+            step equals the last non-NaN value of the corresponding input
+            window's leading ``D_out`` (target) features, or 0 where the
+            entire (node, feature) series is missing.
         """
-        if self._horizon is None:
+        if self._horizon is None or self._output_dim is None:
             raise RuntimeError("Call fit() before predict().")
 
         if hasattr(x_test, "numpy"):
@@ -67,25 +70,28 @@ class LastValueModel(BenchmarkModel):
         else:
             x = np.asarray(x_test, dtype=np.float32)
 
-        # x: [S, L, N, D]
+        # Datasets place target columns as the leading features, so slice the
+        # input down to the first D_out channels before persistence.
+        x = x[:, :, :, : self._output_dim]
+
         # Reverse along the time axis so the most recent timestep is first.
-        x_rev = x[:, ::-1, :, :]  # [S, L, N, D]
+        x_rev = x[:, ::-1, :, :]  # [S, L, N, D_out]
 
         # For each (s, n, d), find the index of the first finite value in the
         # reversed sequence — that is the last observed value in the original.
-        finite = np.isfinite(x_rev)  # [S, L, N, D]
+        finite = np.isfinite(x_rev)  # [S, L, N, D_out]
 
         # argmax returns 0 when no True exists (all-NaN), which maps to the
         # last original timestep — still NaN, cleaned up by nan_to_num below.
-        first_valid = np.argmax(finite, axis=1)  # [S, N, D]
+        first_valid = np.argmax(finite, axis=1)  # [S, N, D_out]
 
         S, _, N, D = x_rev.shape
         s_idx = np.arange(S)[:, None, None]
         n_idx = np.arange(N)[None, :, None]
         d_idx = np.arange(D)[None, None, :]
 
-        last = x_rev[s_idx, first_valid, n_idx, d_idx]  # [S, N, D]
+        last = x_rev[s_idx, first_valid, n_idx, d_idx]  # [S, N, D_out]
         last = np.nan_to_num(last, nan=0.0)              # all-NaN → 0
 
-        # Tile to [S, H, N, D]
+        # Tile to [S, H, N, D_out]
         return np.repeat(last[:, np.newaxis, :, :], self._horizon, axis=1)


### PR DESCRIPTION
## Summary
Updated the `LastValueModel` to properly handle inputs with multiple features by distinguishing between input features (`D_in`) and output/target features (`D_out`). The model now correctly extracts only the target features for persistence forecasting.

## Key Changes
- Added `_output_dim` instance variable to track the number of target features from training data
- Modified `fit()` to capture the output dimension from `y_train.shape[3]`
- Updated `predict()` to slice input features to only the first `D_out` channels before applying the persistence logic
- Improved docstring clarity by distinguishing between input dimension (`D_in`) and output dimension (`D_out`)
- Updated all inline comments to reflect the correct tensor shapes after feature slicing

## Implementation Details
The key insight is that datasets place target columns as the leading features in the input tensor. By storing the output dimension during training and slicing the input to `x[:, :, :, :self._output_dim]` during prediction, the model now correctly handles cases where the input contains additional features beyond the target variables. This ensures the persistence forecast only repeats the relevant target features rather than all input features.

https://claude.ai/code/session_011xTjvBUQeb9bgucmHe44wT