### PR TITLE
Add no-graph ablation support across all benchmark models

### DIFF
--- a/models/ASTGCN/model/ASTGCN_r.py
+++ b/models/ASTGCN/model/ASTGCN_r.py
@@ -178,7 +178,7 @@ class ASTGCN(nn.Module):
 
     def __init__(
         self,
-        adj_mx: np.ndarray,
+        adj_mx: np.ndarray | None,
         nb_block: int,
         in_channels: int,
         K: int,
@@ -189,13 +189,26 @@ class ASTGCN(nn.Module):
         len_input: int,
         num_of_vertices: int,
         output_dim: int = 1,
+        no_graph: bool = False,
     ):
         super().__init__()
-        L_tilde = scaled_laplacian(adj_mx)
-        cheb_polys = [
-            torch.from_numpy(p).to(torch.float32)
-            for p in cheb_polynomials(L_tilde, K)
-        ]
+        if no_graph:
+            # No-graph ablation: replace every Chebyshev polynomial with the
+            # identity matrix. After `T_k.mul(spatial_attention)` the result is
+            # a per-batch diagonal, so the cheb conv becomes a per-node linear
+            # rescaled by each node's own attention score — no cross-node
+            # mixing. SpatialAttention parameters and Theta_k weights stay live.
+            cheb_polys = [
+                torch.eye(num_of_vertices, dtype=torch.float32) for _ in range(K)
+            ]
+        else:
+            if adj_mx is None:
+                raise ValueError("adj_mx is required when no_graph=False")
+            L_tilde = scaled_laplacian(adj_mx)
+            cheb_polys = [
+                torch.from_numpy(p).to(torch.float32)
+                for p in cheb_polynomials(L_tilde, K)
+            ]
 
         self.output_dim = output_dim
         self.num_for_predict = num_for_predict

--- a/models/STAEFormer/model/STAEformer.py
+++ b/models/STAEFormer/model/STAEformer.py
@@ -126,6 +126,7 @@ class STAEformer(nn.Module):
         num_layers=3,
         dropout=0.1,
         use_mixed_proj=True,
+        use_spatial_attn=True,
     ):
         super().__init__()
 
@@ -150,6 +151,7 @@ class STAEformer(nn.Module):
         self.num_heads = num_heads
         self.num_layers = num_layers
         self.use_mixed_proj = use_mixed_proj
+        self.use_spatial_attn = use_spatial_attn
 
         self.input_proj = nn.Linear(input_dim, input_embedding_dim)
         if tod_embedding_dim > 0:
@@ -181,12 +183,19 @@ class STAEformer(nn.Module):
             ]
         )
 
-        self.attn_layers_s = nn.ModuleList(
-            [
-                SelfAttentionLayer(self.model_dim, feed_forward_dim, num_heads, dropout)
-                for _ in range(num_layers)
-            ]
-        )
+        if use_spatial_attn:
+            self.attn_layers_s = nn.ModuleList(
+                [
+                    SelfAttentionLayer(self.model_dim, feed_forward_dim, num_heads, dropout)
+                    for _ in range(num_layers)
+                ]
+            )
+        else:
+            # No-graph ablation: skip cross-node mixing entirely. Each node
+            # is processed independently by the temporal stack + per-node
+            # output projection. Adaptive embedding stays intact since it
+            # is a per-node identity feature, not an adjacency.
+            self.attn_layers_s = nn.ModuleList()
 
     def forward(self, x):
         # x: (batch_size, in_steps, num_nodes, input_dim+tod+dow=3)

--- a/models/astgcn.py
+++ b/models/astgcn.py
@@ -72,6 +72,13 @@ class ASTGCNConfig:
     nb_time_filter: int = 64
     time_strides: int = 1
 
+    # Ablation: replace the Chebyshev polynomials with identity matrices
+    # so the spatial graph convolution stops mixing across nodes (each
+    # node gets a per-node linear rescaled by its own spatial-attention
+    # score). Spatial/temporal attention parameters and Theta weights are
+    # preserved. When True the supplied adjacency is ignored.
+    no_graph: bool = False
+
     # LR scheduler (multi-step decay — unified across all benchmark models)
     use_lr_scheduler: bool = True
     lr_milestones: list[int] = field(default_factory=lambda: [20, 40, 60, 80])
@@ -170,10 +177,9 @@ class ASTGCNModel(BenchmarkModel):
         adj: np.ndarray | None,
         config: Any,
     ) -> TrainingHistory:
-        if adj is None:
-            raise ValueError("adj is required")
-
         cfg = _resolve_config(config)
+        if adj is None and not cfg.no_graph:
+            raise ValueError("adj is required")
         self._cfg = cfg
 
         if cfg.seed is not None:
@@ -221,7 +227,7 @@ class ASTGCNModel(BenchmarkModel):
         )
 
         # -- Build model ---------------------------------------------------
-        adj_mx = np.asarray(adj, dtype=np.float32)
+        adj_mx = None if cfg.no_graph else np.asarray(adj, dtype=np.float32)
         model = ASTGCN(
             adj_mx=adj_mx,
             nb_block=cfg.nb_block,
@@ -234,6 +240,7 @@ class ASTGCNModel(BenchmarkModel):
             len_input=in_steps,
             num_of_vertices=num_nodes,
             output_dim=output_dim,
+            no_graph=cfg.no_graph,
         ).to(device)
 
         # -- Training setup ------------------------------------------------

--- a/models/gwn.py
+++ b/models/gwn.py
@@ -86,6 +86,12 @@ class GWNConfig:
     addaptadj: bool = True
     adjtype: str = "doubletransition"
 
+    # Ablation: drop the spatial component entirely. Routes every layer
+    # through GWN's existing `gcn_bool=False` path (a 1×1 residual conv),
+    # ignoring `supports` and the adaptive adjacency. Overrides
+    # `gcn_bool`/`addaptadj` when True.
+    no_graph: bool = False
+
     # LR scheduler (multi-step decay — unified across all benchmark models)
     use_lr_scheduler: bool = True
     lr_milestones: list[int] = field(default_factory=lambda: [20, 40, 60, 80])
@@ -268,7 +274,10 @@ class GWNModel(BenchmarkModel):
         y_val_d = y_val.to(device)
 
         # -- Build graph supports ------------------------------------------
-        supports, aptinit = _build_supports(adj, cfg.adjtype, device)
+        if cfg.no_graph:
+            supports, aptinit = None, None
+        else:
+            supports, aptinit = _build_supports(adj, cfg.adjtype, device)
 
         # -- DataLoaders ---------------------------------------------------
         train_loader = DataLoader(
@@ -288,8 +297,8 @@ class GWNModel(BenchmarkModel):
             num_nodes=num_nodes,
             dropout=cfg.dropout,
             supports=supports,
-            gcn_bool=cfg.gcn_bool,
-            addaptadj=cfg.addaptadj,
+            gcn_bool=False if cfg.no_graph else cfg.gcn_bool,
+            addaptadj=False if cfg.no_graph else cfg.addaptadj,
             aptinit=aptinit,
             in_dim=input_dim,
             out_dim=out_steps * output_dim,

--- a/models/mtgnn.py
+++ b/models/mtgnn.py
@@ -82,6 +82,12 @@ class MTGNNConfig:
     tanhalpha: float = 3.0
     layer_norm_affline: bool = True
 
+    # Ablation: drop the spatial component entirely. Routes every layer
+    # through MTGNN's existing `gcn_true=False` path (a 1×1 residual conv),
+    # ignoring both the predefined adjacency and the learned graph
+    # constructor. Overrides `gcn_true`/`buildA_true` when True.
+    no_graph: bool = False
+
     # LR scheduler (multi-step decay — unified across all benchmark models)
     use_lr_scheduler: bool = True
     lr_milestones: list[int] = field(default_factory=lambda: [20, 40, 60, 80])
@@ -239,15 +245,17 @@ class MTGNNModel(BenchmarkModel):
         # the second mode is actually usable end-to-end (callers can
         # tune ``buildA_true`` to compare the two).
         predefined_A: torch.Tensor | None = None
-        if not cfg.buildA_true and adj is not None:
+        if cfg.no_graph:
+            predefined_A = None
+        elif not cfg.buildA_true and adj is not None:
             predefined_A = torch.tensor(
                 np.asarray(adj, dtype=np.float32), device=device,
             )
 
         # -- Build model ---------------------------------------------------
         model = gtnet(
-            gcn_true=cfg.gcn_true,
-            buildA_true=cfg.buildA_true,
+            gcn_true=False if cfg.no_graph else cfg.gcn_true,
+            buildA_true=False if cfg.no_graph else cfg.buildA_true,
             gcn_depth=cfg.gcn_depth,
             num_nodes=num_nodes,
             device=device,

--- a/models/mtgode.py
+++ b/models/mtgode.py
@@ -96,6 +96,15 @@ class MTGODEConfig:
     adjoint: bool = False
     perturb: bool = False
 
+    # Ablation: feed an identity adjacency through the existing
+    # `buildA_true=False` path. Inside the CGP block the self-loop +
+    # symmetric-normalization step collapses `I + I` to `I`, so the
+    # propagation `nconv(x, I) = x` and the ODE drift `0.5 * alpha *
+    # (x - x) = 0` — the graph propagation becomes a no-op. The temporal
+    # ODE, dilated inception convs, and end-convs stay intact. Overrides
+    # `buildA_true` and ignores any supplied adjacency.
+    no_graph: bool = False
+
     # LR scheduler (multi-step decay — unified across all benchmark models)
     use_lr_scheduler: bool = True
     lr_milestones: list[int] = field(default_factory=lambda: [20, 40, 60, 80])
@@ -251,14 +260,16 @@ class MTGODEModel(BenchmarkModel):
         # We forward the provided ``adj`` so the second mode is actually
         # usable (callers can tune ``buildA_true`` to compare the two).
         predefined_A: torch.Tensor | None = None
-        if not cfg.buildA_true and adj is not None:
+        if cfg.no_graph:
+            predefined_A = torch.eye(num_nodes, dtype=torch.float32, device=device)
+        elif not cfg.buildA_true and adj is not None:
             predefined_A = torch.tensor(
                 np.asarray(adj, dtype=np.float32), device=device,
             )
 
         # -- Build model ---------------------------------------------------
         model = MTGODE(
-            buildA_true=cfg.buildA_true,
+            buildA_true=False if cfg.no_graph else cfg.buildA_true,
             num_nodes=num_nodes,
             device=device,
             predefined_A=predefined_A,

--- a/models/staeformer.py
+++ b/models/staeformer.py
@@ -85,6 +85,12 @@ class STAEFormerConfig:
     steps_per_day: int = 288
     tod_embedding_dim: int = 0
 
+    # Ablation: drop the spatial self-attention stack. Each node is then
+    # processed independently by the temporal attention stack (and the
+    # per-node output projection). The adaptive embedding stays intact
+    # because it is a per-node positional feature, not an adjacency.
+    no_graph: bool = False
+
     # Runtime
     seed: int | None = None
     device: str = "auto"  # "auto" | "cuda" | "cpu"
@@ -248,6 +254,7 @@ class STAEFormerModel(BenchmarkModel):
             num_layers=cfg.num_layers,
             dropout=cfg.dropout,
             use_mixed_proj=True,
+            use_spatial_attn=not cfg.no_graph,
         ).to(device)
 
         # -- Training setup ------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds a `no_graph` ablation configuration option across all five benchmark models (ASTGCN, GWN, MTGODE, MTGNN, STAEFormer) to enable spatial graph component removal for comparative analysis. When enabled, each model routes data through its existing non-graph pathways, allowing researchers to isolate the contribution of spatial graph convolutions to model performance.

## Key Changes

**ASTGCN** (`models/astgcn.py` and `models/ASTGCN/model/ASTGCN_r.py`):
- Added `no_graph: bool = False` config parameter
- Modified `__init__` to accept optional `adj_mx` and `no_graph` flag
- When `no_graph=True`, replaces Chebyshev polynomials with identity matrices, converting spatial convolution to per-node linear transformations scaled by spatial attention scores
- Preserves spatial/temporal attention parameters and Theta weights

**GWN** (`models/gwn.py`):
- Added `no_graph: bool = False` config parameter
- When enabled, sets `supports=None` and forces `gcn_bool=False`, routing all layers through the 1×1 residual convolution path
- Ignores both predefined and adaptive adjacency matrices

**MTGODE** (`models/mtgode.py`):
- Added `no_graph: bool = False` config parameter
- When enabled, feeds an identity matrix as the predefined adjacency, which collapses to identity after normalization, making graph propagation a no-op
- Preserves temporal ODE dynamics and dilated inception convolutions

**MTGNN** (`models/mtgnn.py`):
- Added `no_graph: bool = False` config parameter
- When enabled, forces `gcn_true=False` and `buildA_true=False`, disabling both predefined and learned graph components
- Routes all layers through 1×1 residual convolutions

**STAEFormer** (`models/staeformer.py` and `models/STAEFormer/model/STAEformer.py`):
- Added `no_graph: bool = False` config parameter
- When enabled, skips spatial self-attention layer construction entirely
- Each node processed independently by temporal attention stack; adaptive embedding (per-node positional feature) remains intact

## Implementation Details
- All ablations preserve non-spatial components (temporal attention, per-node projections, learned parameters)
- Adjacency matrix handling is model-specific: some use identity matrices, others use `None` to skip graph operations
- Configuration changes are backward compatible; default behavior unchanged when `no_graph=False`

https://claude.ai/code/session_01G5BHHorwpAJnHoL5hHRQW8