### PR TITLE
Add ablation study scripts for LamaH-CE models

### DIFF
--- a/ablation_examples/lamah_ce_astgcn_ablation.py
+++ b/ablation_examples/lamah_ce_astgcn_ablation.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""ASTGCN on LamaH-CE (dynamic) with an ablated graph.
+
+Single-run benchmark using the winning ASTGCN hyperparameters from the
+fair-protocol search in ``examples_new/lamah_ce_astgcn_example.py``.  See
+``ablation_examples/_shared.py`` for the ablation contract.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.models import ASTGCNConfig, ASTGCNModel
+
+from _shared import run_ablation
+
+DATASET = "lamah-ce-dynamic"
+
+# Winning ASTGCN config on lamah-ce-dynamic (random search, seed=0).
+config = ASTGCNConfig(
+    K=4,
+    batch_size=16,
+    clip_grad=5.0,
+    device="auto",
+    early_stop=7,
+    eps=1e-8,
+    lr=0.0025518472331495724,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    nb_block=2,
+    nb_chev_filter=32,
+    nb_time_filter=64,
+    seed=None,
+    time_strides=1,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+    no_graph=True,
+)
+
+run_ablation(model=ASTGCNModel(), config=config, dataset_key=DATASET)

--- a/ablation_examples/lamah_ce_gwn_ablation.py
+++ b/ablation_examples/lamah_ce_gwn_ablation.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Graph WaveNet on LamaH-CE (dynamic) with an ablated graph.
+
+Single-run benchmark using the winning GWN hyperparameters from the
+fair-protocol search in ``examples_new/lamah_ce_gwn_example.py``.  See
+``ablation_examples/_shared.py`` for the ablation contract.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.models import GWNConfig, GWNModel
+
+from _shared import run_ablation
+
+DATASET = "lamah-ce-dynamic"
+
+# Winning GWN config on lamah-ce-dynamic (random search, seed=0).
+config = GWNConfig(
+    addaptadj=True,
+    adjtype="doubletransition",
+    batch_size=16,
+    blocks=4,
+    clip_grad=5.0,
+    device="auto",
+    dropout=0.3,
+    early_stop=7,
+    eps=1e-8,
+    gcn_bool=True,
+    kernel_size=2,
+    layers=2,
+    lr=0.0008506042266922006,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    nhid=32,
+    seed=None,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+    no_graph=True,
+)
+
+run_ablation(model=GWNModel(), config=config, dataset_key=DATASET)

--- a/ablation_examples/lamah_ce_mtgnn_ablation.py
+++ b/ablation_examples/lamah_ce_mtgnn_ablation.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""MTGNN on LamaH-CE (dynamic) with an ablated graph.
+
+Single-run benchmark using the winning MTGNN hyperparameters from the
+fair-protocol search in ``examples_new/lamah_ce_mtgnn_example.py``.  See
+``ablation_examples/_shared.py`` for the ablation contract.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.models import MTGNNConfig, MTGNNModel
+
+from _shared import run_ablation
+
+DATASET = "lamah-ce-dynamic"
+
+# Winning MTGNN config on lamah-ce-dynamic (random search, seed=0).
+config = MTGNNConfig(
+    batch_size=16,
+    buildA_true=True,
+    clip_grad=5.0,
+    conv_channels=32,
+    device="auto",
+    dilation_exponential=1,
+    dropout=0.1,
+    early_stop=7,
+    end_channels=128,
+    eps=1e-8,
+    gcn_depth=2,
+    gcn_true=True,
+    layer_norm_affline=True,
+    layers=3,
+    lr=0.0023166431971318405,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    node_dim=40,
+    propalpha=0.05,
+    residual_channels=32,
+    seed=None,
+    skip_channels=64,
+    subgraph_size=20,
+    tanhalpha=3.0,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+    no_graph=True,
+)
+
+run_ablation(model=MTGNNModel(), config=config, dataset_key=DATASET)

--- a/ablation_examples/lamah_ce_mtgode_ablation.py
+++ b/ablation_examples/lamah_ce_mtgode_ablation.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""MTGODE on LamaH-CE (dynamic) with an ablated graph.
+
+Single-run benchmark using the winning MTGODE hyperparameters from the
+fair-protocol search in ``examples_new/lamah_ce_mtgode_example.py``.  See
+``ablation_examples/_shared.py`` for the ablation contract.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.models import MTGODEConfig, MTGODEModel
+
+from _shared import run_ablation
+
+DATASET = "lamah-ce-dynamic"
+
+# Winning MTGODE config on lamah-ce-dynamic (random search, seed=0).
+config = MTGODEConfig(
+    adjoint=False,
+    alpha=2.0,
+    atol=1e-3,
+    batch_size=16,
+    buildA_true=True,
+    clip_grad=5.0,
+    conv_channels=32,
+    device="auto",
+    dilation_exponential=1,
+    dropout=0.3,
+    early_stop=7,
+    end_channels=128,
+    eps=1e-8,
+    ln_affine=True,
+    lr=0.0008506042266922006,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    node_dim=40,
+    perturb=False,
+    rtol=1e-4,
+    seed=None,
+    solver_1="euler",
+    solver_2="euler",
+    step_1=0.5,
+    step_2=0.25,
+    subgraph_size=20,
+    tanhalpha=3.0,
+    time_1=1.0,
+    time_2=1.0,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+    no_graph=True,
+)
+
+run_ablation(model=MTGODEModel(), config=config, dataset_key=DATASET)

--- a/ablation_examples/lamah_ce_staeformer_ablation.py
+++ b/ablation_examples/lamah_ce_staeformer_ablation.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""STAEFormer on LamaH-CE (dynamic) with an ablated graph.
+
+Single-run benchmark using the winning STAEFormer hyperparameters from the
+fair-protocol search in ``examples_new/lamah_ce_staeformer_example.py``.  See
+``ablation_examples/_shared.py`` for the ablation contract.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.models import STAEFormerConfig, STAEFormerModel
+
+from _shared import run_ablation
+
+DATASET = "lamah-ce-dynamic"
+
+# Winning STAEFormer config on lamah-ce-dynamic (random search, seed=0).
+config = STAEFormerConfig(
+    adaptive_embedding_dim=40,
+    batch_size=16,
+    clip_grad=5.0,
+    device="auto",
+    dropout=0.0,
+    early_stop=7,
+    eps=1e-8,
+    feed_forward_dim=256,
+    input_embedding_dim=24,
+    lr=0.002519920701883559,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    num_heads=4,
+    num_layers=2,
+    seed=None,
+    steps_per_day=288,
+    tod_embedding_dim=0,
+    use_lr_scheduler=True,
+    weight_decay=3e-4,
+    no_graph=True,
+)
+
+run_ablation(model=STAEFormerModel(), config=config, dataset_key=DATASET)


### PR DESCRIPTION
## Summary
This PR adds ablation study scripts for five graph neural network models (ASTGCN, GWN, MTGNN, MTGODE, and STAEFormer) evaluated on the LamaH-CE dynamic dataset. These scripts enable testing model performance with ablated graphs to assess the importance of graph structure in predictions.

## Key Changes
- Added `lamah_ce_astgcn_ablation.py`: ASTGCN ablation study with winning hyperparameters from fair-protocol search
- Added `lamah_ce_gwn_ablation.py`: Graph WaveNet ablation study with optimized hyperparameters
- Added `lamah_ce_mtgnn_ablation.py`: MTGNN ablation study with best-found configuration
- Added `lamah_ce_mtgode_ablation.py`: MTGODE ablation study with winning hyperparameters
- Added `lamah_ce_staeformer_ablation.py`: STAEFormer ablation study with optimized hyperparameters

## Implementation Details
- Each script instantiates a model-specific config with hyperparameters derived from the corresponding fair-protocol search (seed=0)
- All configs set `no_graph=True` to enable the ablation study (removing graph structure)
- Scripts follow a consistent pattern: import model and config classes, define dataset key, configure hyperparameters, and call `run_ablation()` from the shared ablation module
- Hyperparameters are preserved exactly as found in the original hyperparameter search to ensure reproducibility
- All scripts reference `ablation_examples/_shared.py` for the ablation contract/methodology

https://claude.ai/code/session_0135zcv3KDBKmxMRSN55UFr6