### PR TITLE
Add ablation studies disabling adaptive graph learning

### DIFF
--- a/ablation_examples/eu_load_gwn_no_adaptive_ablation.py
+++ b/ablation_examples/eu_load_gwn_no_adaptive_ablation.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Graph WaveNet on EU electricity load with the adaptive graph disabled.
+
+Single-run benchmark using the winning GWN hyperparameters from
+``examples_new/eu_load_gwn_example.py``, but with ``addaptadj=False``
+so the model relies solely on the dataset's predefined adjacency
+(processed via ``adjtype="doubletransition"``).  Compare against
+``eu_load_gwn_example.py`` (provided graph + adaptive) and
+``eu_load_gwn_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adaptive adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import GWNConfig, GWNModel
+
+from _shared import WORKSPACE
+
+DATASET = "eu-load"
+
+# Winning GWN config on eu-load (random search, seed=0), with the
+# adaptive adjacency switched off.  ``no_graph`` is left at its default
+# (False) so the predefined adjacency is still consumed.
+config = GWNConfig(
+    addaptadj=False,
+    adjtype="doubletransition",
+    batch_size=32,
+    blocks=3,
+    clip_grad=5.0,
+    device="auto",
+    dropout=0.1,
+    early_stop=7,
+    eps=1e-8,
+    gcn_bool=True,
+    kernel_size=2,
+    layers=2,
+    lr=0.0032726888367412277,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    nhid=64,
+    seed=None,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = GWNModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())

--- a/ablation_examples/eu_load_mtgnn_no_adaptive_ablation.py
+++ b/ablation_examples/eu_load_mtgnn_no_adaptive_ablation.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""MTGNN on EU electricity load with the adaptive graph disabled.
+
+Single-run benchmark using the winning MTGNN hyperparameters from
+``examples_new/eu_load_mtgnn_example.py``, but with ``buildA_true=False``
+so the model uses the dataset's predefined adjacency instead of the
+graph constructor's learned one.  ``gcn_true`` is left True so spatial
+propagation still happens — over the provided graph only.  Compare
+against ``eu_load_mtgnn_example.py`` (learned graph) and
+``eu_load_mtgnn_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import MTGNNConfig, MTGNNModel
+
+from _shared import WORKSPACE
+
+DATASET = "eu-load"
+
+# Winning MTGNN config on eu-load (random search, seed=0), with the
+# learned graph constructor switched off so ``predefined_A`` is used.
+config = MTGNNConfig(
+    batch_size=32,
+    buildA_true=False,
+    clip_grad=5.0,
+    conv_channels=64,
+    device="auto",
+    dilation_exponential=1,
+    dropout=0.1,
+    early_stop=7,
+    end_channels=128,
+    eps=1e-8,
+    gcn_depth=2,
+    gcn_true=True,
+    layer_norm_affline=True,
+    layers=3,
+    lr=0.0032726888367412277,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    node_dim=40,
+    propalpha=0.1,
+    residual_channels=32,
+    seed=None,
+    skip_channels=64,
+    subgraph_size=20,
+    tanhalpha=3.0,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = MTGNNModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())

--- a/ablation_examples/eu_load_mtgode_no_adaptive_ablation.py
+++ b/ablation_examples/eu_load_mtgode_no_adaptive_ablation.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""MTGODE on EU electricity load with the adaptive graph disabled.
+
+Single-run benchmark using the winning MTGODE hyperparameters from
+``examples_new/eu_load_mtgode_example.py``, but with ``buildA_true=False``
+so the model uses the dataset's predefined adjacency instead of the
+graph constructor's learned one.  Compare against
+``eu_load_mtgode_example.py`` (learned graph) and
+``eu_load_mtgode_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import MTGODEConfig, MTGODEModel
+
+from _shared import WORKSPACE
+
+DATASET = "eu-load"
+
+# Winning MTGODE config on eu-load (random search, seed=0), with the
+# learned graph constructor switched off so ``predefined_A`` is used.
+config = MTGODEConfig(
+    adjoint=False,
+    alpha=2.0,
+    atol=1e-3,
+    batch_size=32,
+    buildA_true=False,
+    clip_grad=5.0,
+    conv_channels=64,
+    device="auto",
+    dilation_exponential=1,
+    dropout=0.1,
+    early_stop=7,
+    end_channels=128,
+    eps=1e-8,
+    ln_affine=True,
+    lr=0.003012343636515041,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    node_dim=40,
+    perturb=False,
+    rtol=1e-4,
+    seed=None,
+    solver_1="euler",
+    solver_2="euler",
+    step_1=0.125,
+    step_2=0.25,
+    subgraph_size=20,
+    tanhalpha=3.0,
+    time_1=1.0,
+    time_2=1.0,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = MTGODEModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())


### PR DESCRIPTION
## Summary
This PR adds three new ablation study scripts that evaluate model performance when adaptive graph learning is disabled, allowing isolation of the contribution of learned adjacency matrices to overall model performance.

## Key Changes
- **eu_load_mtgode_no_adaptive_ablation.py**: MTGODE ablation with `buildA_true=False` to use only the predefined adjacency matrix instead of the learned graph
- **eu_load_mtgnn_no_adaptive_ablation.py**: MTGNN ablation with `buildA_true=False` while keeping `gcn_true=True` to maintain spatial propagation over the predefined graph only
- **eu_load_gwn_no_adaptive_ablation.py**: Graph WaveNet ablation with `addaptadj=False` to disable the adaptive adjacency while retaining the predefined graph

## Implementation Details
Each ablation script:
- Uses the winning hyperparameters from the corresponding full example (with learned graphs)
- Disables only the adaptive/learned graph component while keeping other architectural features intact
- Provides a direct comparison point against both the full model (with learned graph) and the no-graph baseline
- Includes clear documentation explaining the ablation setup and what is being isolated
- Runs as a single-run benchmark without hyperparameter tuning

These ablations enable quantitative assessment of how much performance improvement comes from the models' graph learning capabilities versus using only the dataset's predefined adjacency structure.

https://claude.ai/code/session_01L4qhtKkf5do9P6crueKrSC