### PR TITLE
Add no-adaptive ablation benchmarks for GWN, MTGNN, and MTGODE

### DIFF
--- a/ablation_examples/chicago_bikes_gwn_no_adaptive_ablation.py
+++ b/ablation_examples/chicago_bikes_gwn_no_adaptive_ablation.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Graph WaveNet on Chicago / Divvy bikeshare with the adaptive graph disabled.
+
+Single-run benchmark using the winning GWN hyperparameters from
+``examples_new/chicago_bikes_gwn_example.py``, but with ``addaptadj=False``
+so the model relies solely on the dataset's predefined adjacency
+(processed via ``adjtype="doubletransition"``).  Compare against
+``chicago_bikes_gwn_example.py`` (provided graph + adaptive) and
+``chicago_bikes_gwn_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adaptive adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import GWNConfig, GWNModel
+
+from _shared import WORKSPACE
+
+DATASET = "divvy-bikeshare-static"
+
+# Winning GWN config on divvy-bikeshare-static (random search, seed=0),
+# with the adaptive adjacency switched off.  ``no_graph`` is left at its
+# default (False) so the predefined adjacency is still consumed.
+config = GWNConfig(
+    addaptadj=False,
+    adjtype="doubletransition",
+    batch_size=16,
+    blocks=4,
+    clip_grad=5.0,
+    device="auto",
+    dropout=0.3,
+    early_stop=7,
+    eps=1e-8,
+    gcn_bool=True,
+    kernel_size=2,
+    layers=2,
+    lr=0.0008506042266922006,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    nhid=32,
+    seed=None,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = GWNModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())

--- a/ablation_examples/chicago_bikes_mtgnn_no_adaptive_ablation.py
+++ b/ablation_examples/chicago_bikes_mtgnn_no_adaptive_ablation.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""MTGNN on Chicago / Divvy bikeshare with the adaptive graph disabled.
+
+Single-run benchmark using the winning MTGNN hyperparameters from
+``examples_new/chicago_bikes_mtgnn_example.py``, but with ``buildA_true=False``
+so the model uses the dataset's predefined adjacency instead of the
+graph constructor's learned one.  ``gcn_true`` is left True so spatial
+propagation still happens — over the provided graph only.  Compare
+against ``chicago_bikes_mtgnn_example.py`` (learned graph) and
+``chicago_bikes_mtgnn_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import MTGNNConfig, MTGNNModel
+
+from _shared import WORKSPACE
+
+DATASET = "divvy-bikeshare-static"
+
+# Winning MTGNN config on divvy-bikeshare-static (random search, seed=0),
+# with the learned graph constructor switched off so ``predefined_A`` is used.
+config = MTGNNConfig(
+    batch_size=16,
+    buildA_true=False,
+    clip_grad=5.0,
+    conv_channels=32,
+    device="auto",
+    dilation_exponential=1,
+    dropout=0.3,
+    early_stop=7,
+    end_channels=128,
+    eps=1e-8,
+    gcn_depth=2,
+    gcn_true=True,
+    layer_norm_affline=True,
+    layers=3,
+    lr=0.0017376497751926923,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    node_dim=40,
+    propalpha=0.1,
+    residual_channels=32,
+    seed=None,
+    skip_channels=64,
+    subgraph_size=20,
+    tanhalpha=3.0,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = MTGNNModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())

--- a/ablation_examples/chicago_bikes_mtgode_no_adaptive_ablation.py
+++ b/ablation_examples/chicago_bikes_mtgode_no_adaptive_ablation.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""MTGODE on Chicago / Divvy bikeshare with the adaptive graph disabled.
+
+Single-run benchmark using the winning MTGODE hyperparameters from
+``examples_new/chicago_bikes_mtgode_example.py``, but with ``buildA_true=False``
+so the model uses the dataset's predefined adjacency instead of the
+graph constructor's learned one.  Compare against
+``chicago_bikes_mtgode_example.py`` (learned graph) and
+``chicago_bikes_mtgode_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import MTGODEConfig, MTGODEModel
+
+from _shared import WORKSPACE
+
+DATASET = "divvy-bikeshare-static"
+
+# Winning MTGODE config on divvy-bikeshare-static (random search, seed=0),
+# with the learned graph constructor switched off so ``predefined_A`` is used.
+config = MTGODEConfig(
+    adjoint=False,
+    alpha=2.0,
+    atol=1e-3,
+    batch_size=16,
+    buildA_true=False,
+    clip_grad=5.0,
+    conv_channels=32,
+    device="auto",
+    dilation_exponential=1,
+    dropout=0.0,
+    early_stop=7,
+    end_channels=128,
+    eps=1e-8,
+    ln_affine=True,
+    lr=0.002519920701883559,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    node_dim=40,
+    perturb=False,
+    rtol=1e-4,
+    seed=None,
+    solver_1="euler",
+    solver_2="euler",
+    step_1=0.125,
+    step_2=0.25,
+    subgraph_size=20,
+    tanhalpha=3.0,
+    time_1=1.0,
+    time_2=1.0,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = MTGODEModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())

--- a/ablation_examples/lamah_ce_gwn_no_adaptive_ablation.py
+++ b/ablation_examples/lamah_ce_gwn_no_adaptive_ablation.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Graph WaveNet on LamaH-CE (dynamic) with the adaptive graph disabled.
+
+Single-run benchmark using the winning GWN hyperparameters from
+``examples_new/lamah_ce_gwn_example.py``, but with ``addaptadj=False``
+so the model relies solely on the dataset's predefined adjacency
+(processed via ``adjtype="doubletransition"``).  Compare against
+``lamah_ce_gwn_example.py`` (provided graph + adaptive) and
+``lamah_ce_gwn_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adaptive adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import GWNConfig, GWNModel
+
+from _shared import WORKSPACE
+
+DATASET = "lamah-ce-dynamic"
+
+# Winning GWN config on lamah-ce-dynamic (random search, seed=0), with
+# the adaptive adjacency switched off.  ``no_graph`` is left at its
+# default (False) so the predefined adjacency is still consumed.
+config = GWNConfig(
+    addaptadj=False,
+    adjtype="doubletransition",
+    batch_size=16,
+    blocks=4,
+    clip_grad=5.0,
+    device="auto",
+    dropout=0.3,
+    early_stop=7,
+    eps=1e-8,
+    gcn_bool=True,
+    kernel_size=2,
+    layers=2,
+    lr=0.0008506042266922006,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    nhid=32,
+    seed=None,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = GWNModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())

--- a/ablation_examples/lamah_ce_mtgnn_no_adaptive_ablation.py
+++ b/ablation_examples/lamah_ce_mtgnn_no_adaptive_ablation.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""MTGNN on LamaH-CE (dynamic) with the adaptive graph disabled.
+
+Single-run benchmark using the winning MTGNN hyperparameters from
+``examples_new/lamah_ce_mtgnn_example.py``, but with ``buildA_true=False``
+so the model uses the dataset's predefined adjacency instead of the
+graph constructor's learned one.  ``gcn_true`` is left True so spatial
+propagation still happens — over the provided graph only.  Compare
+against ``lamah_ce_mtgnn_example.py`` (learned graph) and
+``lamah_ce_mtgnn_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import MTGNNConfig, MTGNNModel
+
+from _shared import WORKSPACE
+
+DATASET = "lamah-ce-dynamic"
+
+# Winning MTGNN config on lamah-ce-dynamic (random search, seed=0), with
+# the learned graph constructor switched off so ``predefined_A`` is used.
+config = MTGNNConfig(
+    batch_size=16,
+    buildA_true=False,
+    clip_grad=5.0,
+    conv_channels=32,
+    device="auto",
+    dilation_exponential=1,
+    dropout=0.1,
+    early_stop=7,
+    end_channels=128,
+    eps=1e-8,
+    gcn_depth=2,
+    gcn_true=True,
+    layer_norm_affline=True,
+    layers=3,
+    lr=0.0023166431971318405,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    node_dim=40,
+    propalpha=0.05,
+    residual_channels=32,
+    seed=None,
+    skip_channels=64,
+    subgraph_size=20,
+    tanhalpha=3.0,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = MTGNNModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())

--- a/ablation_examples/lamah_ce_mtgode_no_adaptive_ablation.py
+++ b/ablation_examples/lamah_ce_mtgode_no_adaptive_ablation.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""MTGODE on LamaH-CE (dynamic) with the adaptive graph disabled.
+
+Single-run benchmark using the winning MTGODE hyperparameters from
+``examples_new/lamah_ce_mtgode_example.py``, but with ``buildA_true=False``
+so the model uses the dataset's predefined adjacency instead of the
+graph constructor's learned one.  Compare against
+``lamah_ce_mtgode_example.py`` (learned graph) and
+``lamah_ce_mtgode_ablation.py`` (no graph at all) to isolate the
+contribution of the learned adjacency.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from gnn_benchmark.benchmark import BenchmarkRunner
+from gnn_benchmark.models import MTGODEConfig, MTGODEModel
+
+from _shared import WORKSPACE
+
+DATASET = "lamah-ce-dynamic"
+
+# Winning MTGODE config on lamah-ce-dynamic (random search, seed=0), with
+# the learned graph constructor switched off so ``predefined_A`` is used.
+config = MTGODEConfig(
+    adjoint=False,
+    alpha=2.0,
+    atol=1e-3,
+    batch_size=16,
+    buildA_true=False,
+    clip_grad=5.0,
+    conv_channels=32,
+    device="auto",
+    dilation_exponential=1,
+    dropout=0.3,
+    early_stop=7,
+    end_channels=128,
+    eps=1e-8,
+    ln_affine=True,
+    lr=0.0008506042266922006,
+    lr_decay_ratio=0.5,
+    lr_milestones=[10, 15],
+    max_epochs=20,
+    node_dim=40,
+    perturb=False,
+    rtol=1e-4,
+    seed=None,
+    solver_1="euler",
+    solver_2="euler",
+    step_1=0.5,
+    step_2=0.25,
+    subgraph_size=20,
+    tanhalpha=3.0,
+    time_1=1.0,
+    time_2=1.0,
+    use_lr_scheduler=True,
+    weight_decay=1e-4,
+)
+
+model = MTGODEModel()
+print(
+    f"[no-adaptive ablation] {model.name} on {DATASET} — "
+    "predefined graph only (single run, no tuning)"
+)
+runner = BenchmarkRunner(workspace_dir=WORKSPACE, datasets=[DATASET])
+result = runner.run(model, config=config)
+print(result.summary())


### PR DESCRIPTION
## Summary
This PR adds six new ablation study benchmark scripts that evaluate graph neural network models with their adaptive/learned graph construction disabled, using only predefined adjacency matrices. These benchmarks enable isolation of the contribution of learned graph components to model performance.

## Key Changes
- **Added 6 new ablation benchmark scripts** in `ablation_examples/`:
  - `chicago_bikes_gwn_no_adaptive_ablation.py` - GWN on Divvy bikeshare with `addaptadj=False`
  - `lamah_ce_gwn_no_adaptive_ablation.py` - GWN on LamaH-CE with `addaptadj=False`
  - `chicago_bikes_mtgnn_no_adaptive_ablation.py` - MTGNN on Divvy bikeshare with `buildA_true=False`
  - `lamah_ce_mtgnn_no_adaptive_ablation.py` - MTGNN on LamaH-CE with `buildA_true=False`
  - `chicago_bikes_mtgode_no_adaptive_ablation.py` - MTGODE on Divvy bikeshare with `buildA_true=False`
  - `lamah_ce_mtgode_no_adaptive_ablation.py` - MTGODE on LamaH-CE with `buildA_true=False`

## Implementation Details
- Each script uses the winning hyperparameters from the corresponding full example (with learned graphs enabled)
- The key difference is disabling the adaptive graph construction:
  - **GWN**: Sets `addaptadj=False` while keeping `gcn_bool=True` and `adjtype="doubletransition"`
  - **MTGNN**: Sets `buildA_true=False` while keeping `gcn_true=True` for spatial propagation
  - **MTGODE**: Sets `buildA_true=False` to use only predefined adjacency
- All scripts follow the same pattern: single-run benchmarks with no hyperparameter tuning
- Each includes documentation explaining how to compare results against the full model and no-graph baselines to isolate the learned graph contribution

https://claude.ai/code/session_01MJz5HRn5Y6zgUwiT9sHUA8