### PR TITLE
Update Google Drive IDs for multiple dataset loaders

### DIFF
--- a/DIVVY_BIKESHARE.md
+++ b/DIVVY_BIKESHARE.md
@@ -12,7 +12,7 @@ were needed to support time-varying edges.
   `https://divvy-tripdata.s3.amazonaws.com/`.
 - **Combined artifact:** a single parquet bundling many months, produced
   offline by `scripts/combine_divvy_tripdata.py` and uploaded once to
-  Google Drive. ID = `185BbpyzAS5YvKGfKtNCv3tlhPYKqNbX5`. Current
+  Google Drive. ID = `1r2rfVNDgjcJiJO3lGOCK81AF7cDjHAKZ`. Current
   coverage: 2024-03 through 2026-03 (25 months, ~11.7 M trips,
   ~402 MB).
 - **Download path** (when `data_path=None`): resolved in this order by

--- a/datasets/divvy_bikeshare.py
+++ b/datasets/divvy_bikeshare.py
@@ -20,7 +20,7 @@ except ImportError:
 
 # Google Drive ID for the combined parquet covering 2024-03..2026-03.
 # Produced by scripts/combine_divvy_tripdata.py and uploaded once.
-GDRIVE_ID = "185BbpyzAS5YvKGfKtNCv3tlhPYKqNbX5"
+GDRIVE_ID = "1r2rfVNDgjcJiJO3lGOCK81AF7cDjHAKZ"
 
 # Cache directory for the downloaded parquet. First run downloads to
 # ``_CACHE_PATH``; subsequent runs reuse the cached file. Users can still

--- a/datasets/eu_load.py
+++ b/datasets/eu_load.py
@@ -20,10 +20,10 @@ except ImportError:
 
 
 # Google Drive IDs for the source files.
-EDGES_GDRIVE_ID = "12QPWAwGr-36cLQ3TB-KbGE34om3TODH1"
-LOAD_GDRIVE_ID = "1mLjtYlbu4cTIAJKDjlD2dS-Zdq-n0ED0"
+EDGES_GDRIVE_ID = "1Fxz9GWMGnOVXnrAr7A_e7xb2zMoYQxQW"
+LOAD_GDRIVE_ID = "1GKd6PCu-Y_Q771IgBsAELp5e8LHwKGR_"
 # Hourly directed cross-zone flow snapshots.
-DYNAMIC_EDGES_GDRIVE_ID = "1OFaI90bkcTBS_VAk03umCoJbS9nHVg7W"
+DYNAMIC_EDGES_GDRIVE_ID = "1K-ZR6UToCdIMhYUEIQ-a15h4Ebe8mwZE"
 
 FREQ = "1h"
 

--- a/datasets/noaa_buoy.py
+++ b/datasets/noaa_buoy.py
@@ -42,8 +42,8 @@ except ImportError:
 # ── Constants ─────────────────────────────────────────────────────────────────
 
 # Google Drive file IDs for the pre-fetched NOAA buoy data.
-_STATIONS_GDRIVE_ID = "1m1y-2zsTwdPjK8tV2BqluzM2aNf4DJLf"
-_DATA_GDRIVE_ID = "1KKmQ7v18kQ1mMNuBG00c4wBOXDmYraDp"
+_STATIONS_GDRIVE_ID = "1brU5qePbtB1fSyAKlGK2LF4nwIqago61"
+_DATA_GDRIVE_ID = "1ER228VCA8Yi92UD5gLQGKYpFlHdkYr5T"
 
 _YEARS = (2022, 2023, 2024, 2025)
 

--- a/datasets/pems_speed.py
+++ b/datasets/pems_speed.py
@@ -87,8 +87,8 @@ PEMS_BAY_NODE_ORDER = [
 ]
 
 # Google Drive IDs for data files
-PEMS_BAY_GDRIVE_ID = "1wD-mHlqAb2mtHOe_68fZvDh1LpDegMMq"
-METRLA_GDRIVE_ID = "1pAGRfzMx6K9WWsfDcD1NMbIif0T0saFC"
+PEMS_BAY_GDRIVE_ID = "1qhPgBUP_lFdRsrUtzJ1oZx_Dejpy5D0f"
+METRLA_GDRIVE_ID = "1GNQYGgPNIyZ7sEcEDs6ObW6GSqaOw10C"
 
 # URLs for adjacency matrices
 PEMS_BAY_ADJ_URL = "https://raw.githubusercontent.com/chnsh/DCRNN/master/data/sensor_graph/adj_mx_bay.pkl"


### PR DESCRIPTION
### Motivation

- Rotate or correct the hard-coded Google Drive file IDs used by several dataset loaders and the Divvy dataset documentation to point to the current pre-fetched artifacts.

### Description

- Replaced the Google Drive ID in `datasets/divvy_bikeshare.py` and the corresponding reference in `DIVVY_BIKESHARE.md` so the combined Divvy parquet download uses the updated `GDRIVE_ID`.
- Updated `EDGES_GDRIVE_ID`, `LOAD_GDRIVE_ID`, and `DYNAMIC_EDGES_GDRIVE_ID` in `datasets/eu_load.py` to the new Drive IDs for ENTSO-E source files.
- Replaced `_STATIONS_GDRIVE_ID` and `_DATA_GDRIVE_ID` in `datasets/noaa_buoy.py` with the new Drive IDs for the pre-fetched NOAA buoy files.
- Updated `PEMS_BAY_GDRIVE_ID` and `METRLA_GDRIVE_ID` in `datasets/pems_speed.py` to point at the current Drive artifacts.

### Testing

- Ran the test suite with `pytest -q` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad1da694c832082c046494ebd5b59)