### PR TITLE
Update LamaH-CE Google Drive file ID

### DIFF
--- a/datasets/_lamah_ce_download.py
+++ b/datasets/_lamah_ce_download.py
@@ -24,7 +24,7 @@ except ImportError:
 # Pre-mirrored LamaH-CE archive on Google Drive. Same daily layout as the
 # Zenodo release (record 4525244) but hosted where we get a reliable fetch
 # instead of intermittent 404s.
-_LAMAH_GDRIVE_ID = "1-gMtrag7EtAqhuMB2sJfc85whd8iRLEt"
+_LAMAH_GDRIVE_ID = "1JEpgwAspF2RQyjCAKY8Ave15KMh3q4aJ"
 _LAMAH_TARBALL_NAME = "lamah_ce.tar.gz"
 
 


### PR DESCRIPTION
### Motivation
- Replace the LamaH-CE Google Drive file ID used for `gdown` downloads with the current mirrored ID to restore reliable dataset fetches.

### Description
- Updated the `_LAMAH_GDRIVE_ID` constant in `datasets/_lamah_ce_download.py` from `1-gMtrag7EtAqhuMB2sJfc85whd8iRLEt` to `1JEpgwAspF2RQyjCAKY8Ave15KMh3q4aJ`.

### Testing
- Compiled the modified file with `python -m py_compile datasets/_lamah_ce_download.py` and the command succeeded.  
- Verified the old ID is no longer present with `rg -n "1-gMtrag7EtAqhuMB2sJfc85whd8iRLEt" -S .`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faf6bcbccc83209b752afc2c3b0e4b)