### PR TITLE
Fix station_id type coercion bug in Beijing air edge computation

### DIFF
--- a/datasets/beijing_air.py
+++ b/datasets/beijing_air.py
@@ -215,18 +215,22 @@ class _BaseAirQualityLoader(DatasetLoader):
         stations = stations[stations["station_id"].isin(node_ids)]
         stations = stations[["station_id", "latitude", "longitude"]].reset_index(drop=True)
 
+        # Use itertuples (not iterrows): a row Series promotes int station_id
+        # to float to share a dtype with the lat/lon columns, so str(...) would
+        # yield "1001.0" and silently miss every node_id lookup downstream,
+        # producing an all-zero adjacency.
         rows = []
-        for i, row_i in stations.iterrows():
-            for j, row_j in stations.iterrows():
-                if row_i["station_id"] == row_j["station_id"]:
+        for row_i in stations.itertuples(index=False):
+            for row_j in stations.itertuples(index=False):
+                if row_i.station_id == row_j.station_id:
                     continue
                 d = haversine_distance(
-                    row_i["latitude"],
-                    row_i["longitude"],
-                    row_j["latitude"],
-                    row_j["longitude"],
+                    row_i.latitude,
+                    row_i.longitude,
+                    row_j.latitude,
+                    row_j.longitude,
                 )
-                rows.append((str(row_i["station_id"]), str(row_j["station_id"]), d))
+                rows.append((str(row_i.station_id), str(row_j.station_id), d))
 
         edges = pd.DataFrame(rows, columns=["src", "dst", "cost"])
         return edges


### PR DESCRIPTION
## Summary
Fixed a subtle bug in the `_compute_edges` method where `iterrows()` was causing integer `station_id` values to be promoted to floats, resulting in failed node lookups and an all-zero adjacency matrix.

## Key Changes
- Replaced `iterrows()` with `itertuples(index=False)` to preserve the original data types of DataFrame columns
- Updated row access from dictionary-style (`row["column"]`) to attribute-style (`row.column`) to match the namedtuple interface
- Added explanatory comment documenting why `itertuples()` is necessary and the consequences of the previous approach

## Implementation Details
The bug occurred because `iterrows()` returns a Series for each row, which promotes integer columns to float when they share a dtype with other numeric columns (latitude/longitude). This caused `str(row_i["station_id"])` to produce values like `"1001.0"` instead of `"1001"`, silently failing all downstream node_id lookups.

Using `itertuples()` preserves the original dtypes and provides better performance as a bonus.

https://claude.ai/code/session_015bQsUynKomfKvjZyQeKpfK