### PR TITLE
Fix scaled Laplacian computation for robustness on small graphs

### DIFF
--- a/models/ASTGCN/model/ASTGCN_r.py
+++ b/models/ASTGCN/model/ASTGCN_r.py
@@ -11,7 +11,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from scipy.sparse.linalg import eigs
 
 
 # ---------------------------------------------------------------------------
@@ -21,9 +20,16 @@ from scipy.sparse.linalg import eigs
 def scaled_laplacian(W: np.ndarray) -> np.ndarray:
     """Compute the scaled Laplacian ``2L/lambda_max - I`` for adjacency W."""
     assert W.shape[0] == W.shape[1]
-    D = np.diag(np.sum(W, axis=1))
-    L = D - W
-    lambda_max = eigs(L, k=1, which="LR")[0].real
+    # Symmetrize defensively — floating-point asymmetry would make L non-Hermitian.
+    W_sym = np.maximum(W, W.T)
+    D = np.diag(np.sum(W_sym, axis=1))
+    L = D - W_sym
+    # L is real symmetric, so eigvalsh is exact and numerically robust.
+    # ARPACK's eigs(..., which="LR") fails with "Starting vector is zero" on
+    # small or ill-conditioned Laplacians (e.g. Beijing Air, N=36).
+    lambda_max = float(np.linalg.eigvalsh(L)[-1])
+    if lambda_max <= 0:
+        lambda_max = 2.0
     return (2 * L) / lambda_max - np.identity(W.shape[0])
 
 


### PR DESCRIPTION
## Summary
Improved the numerical robustness of the scaled Laplacian computation in ASTGCN by replacing ARPACK's eigenvalue solver with NumPy's dense eigenvalue solver and adding defensive symmetrization of the adjacency matrix.

## Key Changes
- **Removed ARPACK dependency**: Replaced `scipy.sparse.linalg.eigs()` with `np.linalg.eigvalsh()` for computing the maximum eigenvalue of the Laplacian matrix
- **Added adjacency symmetrization**: Defensively symmetrize the adjacency matrix using `np.maximum(W, W.T)` to ensure the Laplacian is Hermitian and avoid numerical issues
- **Added fallback handling**: Implemented a safety check that defaults `lambda_max` to 2.0 if it computes to a non-positive value
- **Improved robustness**: The new approach resolves failures on small or ill-conditioned graphs (e.g., Beijing Air dataset with N=36) where ARPACK would fail with "Starting vector is zero" error

## Implementation Details
- `eigvalsh()` is more numerically stable than `eigs()` for real symmetric matrices and doesn't require ARPACK's iterative solver
- The symmetrization step ensures floating-point asymmetries in the adjacency matrix don't propagate to the Laplacian computation
- The fallback to `lambda_max = 2.0` provides a sensible default for degenerate cases while maintaining mathematical validity

https://claude.ai/code/session_01LsUCYmvtmXKZuQfQ2s4jnD